### PR TITLE
Arreglando el deploy a staging

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,15 +14,15 @@ _APP_ENV = "'development'"
 mode = "smart"
 
 [[queues.producers]]
-queue = "mail-queue-staging"
+queue = "mail-queue-dev"
 binding = "MAIL_QUEUE"
 
 [[queues.consumers]]
-queue = "mail-queue-staging"
+queue = "mail-queue-dev"
 max_batch_size = 10
 max_batch_timeout = 30
 max_retries = 10
-dead_letter_queue = "deadletter-mail-queue-staging"
+dead_letter_queue = "deadletter-mail-queue-dev"
 
 
 


### PR DESCRIPTION
Estabamos teniendo el siguiente error.
Esto era mas que nada porque una cola no puede tener multiples "listeners"  (Estaba "DEV" escuchando la 
 misma cola que "STAGING")
 
Ahora creé una cola específica para "DEV" , asi que no debería fallar 🙏 

```
✘ [ERROR] A request to the Cloudflare API (/accounts/6e3497a44104902c23f58fe79ee984b6/workers/queues/mail-queue-staging/consumers/graphql-api-staging) failed.

  workers.api.error.consumer_exists [code: 11004]
  
  If you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose

```