### PR TITLE
Corrección de Filtro en Query de Eventos Asociados a Comunidades

### DIFF
--- a/src/generated/schema.gql
+++ b/src/generated/schema.gql
@@ -91,6 +91,12 @@ A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `dat
 """
 scalar DateTime
 
+input EnqueueGoogleAlbumImportInput {
+  albumId: String!
+  sanityEventInstanceId: String!
+  token: String!
+}
+
 """
 Representation of an Event (Events and Users, is what tickets are linked to)
 """
@@ -213,6 +219,11 @@ type Mutation {
   editTicket(input: TicketEditInput!): Ticket!
 
   """
+  Enqueue images to import
+  """
+  enqueueGoogleAlbumImport(input: EnqueueGoogleAlbumImportInput!): Boolean!
+
+  """
   Redeem a ticket
   """
   redeemUserTicket(userTicketId: String!): UserTicket!
@@ -288,6 +299,11 @@ type Query {
   events(input: EventsSearchInput): [Event!]!
 
   """
+  Get the current user
+  """
+  me: User!
+
+  """
   Get a list of tickets for the current user
   """
   myTickets(input: MyTicketsSearchInput): [UserTicket!]!
@@ -324,6 +340,18 @@ type Salary {
   workMetodology: WorkMetodology!
   workRole: WorkRole!
   yearsOfExperience: Int!
+}
+
+"""
+Representation of a Sanity Asset
+"""
+type SanityAssetRef {
+  assetId: String!
+  id: String!
+  originalFilename: String!
+  path: String!
+  size: Int!
+  url: String!
 }
 
 input SearchCompaniesInput {
@@ -421,6 +449,9 @@ enum TypeOfEmployment {
 
 input UpdateCommunityInput {
   communityId: String!
+  description: String
+  name: String
+  slug: String
   status: CommnunityStatus
 }
 
@@ -455,6 +486,7 @@ type User {
   bio: String
   communities: [Community!]!
   id: String!
+  isSuperAdmin: Boolean
   lastName: String
   name: String
   username: String!

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -110,6 +110,12 @@ export type CreateSalaryInput = {
   yearsOfExperience: Scalars["Int"]["input"];
 };
 
+export type EnqueueGoogleAlbumImportInput = {
+  albumId: Scalars["String"]["input"];
+  sanityEventInstanceId: Scalars["String"]["input"];
+  token: Scalars["String"]["input"];
+};
+
 /** Representation of an Event (Events and Users, is what tickets are linked to) */
 export type Event = {
   __typename?: "Event";
@@ -212,6 +218,8 @@ export type Mutation = {
   editCommunity: Community;
   /** Edit a ticket */
   editTicket: Ticket;
+  /** Enqueue images to import */
+  enqueueGoogleAlbumImport: Scalars["Boolean"]["output"];
   /** Redeem a ticket */
   redeemUserTicket: UserTicket;
   /** Kickoff the email validation flow. This flow will links an email to a user, create a company if it does not exist, and allows filling data for that email's position */
@@ -258,6 +266,10 @@ export type MutationEditCommunityArgs = {
 
 export type MutationEditTicketArgs = {
   input: TicketEditInput;
+};
+
+export type MutationEnqueueGoogleAlbumImportArgs = {
+  input: EnqueueGoogleAlbumImportInput;
 };
 
 export type MutationRedeemUserTicketArgs = {
@@ -310,6 +322,8 @@ export type Query = {
   event?: Maybe<Event>;
   /** Get a list of events. Filter by name, id, status or date */
   events: Array<Event>;
+  /** Get the current user */
+  me: User;
   /** Get a list of tickets for the current user */
   myTickets: Array<UserTicket>;
   status: Scalars["String"]["output"];
@@ -377,6 +391,17 @@ export type Salary = {
   workMetodology: WorkMetodology;
   workRole: WorkRole;
   yearsOfExperience: Scalars["Int"]["output"];
+};
+
+/** Representation of a Sanity Asset */
+export type SanityAssetRef = {
+  __typename?: "SanityAssetRef";
+  assetId: Scalars["String"]["output"];
+  id: Scalars["String"]["output"];
+  originalFilename: Scalars["String"]["output"];
+  path: Scalars["String"]["output"];
+  size: Scalars["Int"]["output"];
+  url: Scalars["String"]["output"];
 };
 
 export type SearchCompaniesInput = {
@@ -472,6 +497,9 @@ export enum TypeOfEmployment {
 
 export type UpdateCommunityInput = {
   communityId: Scalars["String"]["input"];
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  slug?: InputMaybe<Scalars["String"]["input"]>;
   status?: InputMaybe<CommnunityStatus>;
 };
 
@@ -505,6 +533,7 @@ export type User = {
   bio?: Maybe<Scalars["String"]["output"]>;
   communities: Array<Community>;
   id: Scalars["String"]["output"];
+  isSuperAdmin?: Maybe<Scalars["Boolean"]["output"]>;
   lastName?: Maybe<Scalars["String"]["output"]>;
   name?: Maybe<Scalars["String"]["output"]>;
   username: Scalars["String"]["output"];

--- a/src/tests/community/community.test.ts
+++ b/src/tests/community/community.test.ts
@@ -201,8 +201,8 @@ describe("Communities", () => {
       assert.equal(responseCommunity.id, community.id);
       assert.equal(responseCommunity.events.length, events.length);
 
-      events.forEach((event, eventIndex) => {
-        assert.equal(responseCommunity.events[eventIndex].id, event.id);
+      responseCommunity.events.forEach((someResponseEvent) => {
+        assert.exists(events.find((e) => e.id === someResponseEvent.id));
       });
     });
   });

--- a/src/tests/community/getCommunities/getCommunities.generated.ts
+++ b/src/tests/community/getCommunities/getCommunities.generated.ts
@@ -13,7 +13,7 @@ export type CommunitiesQueryVariables = Types.Exact<{
 }>;
 
 
-export type CommunitiesQuery = { __typename?: 'Query', communities: Array<{ __typename?: 'Community', description: string | null, id: string, name: string | null, status: Types.CommnunityStatus }> };
+export type CommunitiesQuery = { __typename?: 'Query', communities: Array<{ __typename?: 'Community', description: string | null, id: string, name: string | null, status: Types.CommnunityStatus, events: Array<{ __typename?: 'Event', id: string }> }> };
 
 
 export const Communities = gql`
@@ -23,6 +23,9 @@ export const Communities = gql`
     id
     name
     status
+    events {
+      id
+    }
   }
 }
     `;

--- a/src/tests/community/getCommunities/getCommunities.gql
+++ b/src/tests/community/getCommunities/getCommunities.gql
@@ -12,5 +12,8 @@ query Communities(
     id
     name
     status
+    events {
+      id
+    }
   }
 }


### PR DESCRIPTION
Este Pull Request resuelve el issue #81.

Los cambios realizados ajustan la lógica de consulta dentro de `src/schema/community.ts`.

Se modificó la consulta de eventos para usar el método `inArray`, asegurando que solo se devuelvan los eventos vinculados a la comunidad en cuestión.

Antes:
![Screenshot 2023-11-26 at 02-29-32 JSChileORG GraphiQL](https://github.com/JSConfCL/gql_api/assets/37272605/bd354e2f-9546-45a4-b047-38feed4c0342)

Después:
![Screenshot 2023-11-26 at 02-28-49 JSChileORG GraphiQL](https://github.com/JSConfCL/gql_api/assets/37272605/d83004ee-c396-4600-9462-1d1c33c44312)
