### PR TITLE
BUG: Creación duplicada de la carpeta de bases de datos de prueba durante yarn test

### DIFF
--- a/src/tests/__fixtures/databaseHelper.ts
+++ b/src/tests/__fixtures/databaseHelper.ts
@@ -2,21 +2,17 @@
 import { faker } from "@faker-js/faker";
 import { createClient } from "@libsql/client";
 import { exec } from "node:child_process";
-import { existsSync, mkdirSync } from "node:fs";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate } from "drizzle-orm/libsql/migrator";
 import * as schema from "~/datasources/db/schema";
 import { ORM_TYPE } from "~/datasources/db";
 
-const testDabasesFolder = `.test_dbs`;
-const migrationsFolder = `${process.cwd()}/drizzle/migrations`;
-/* c8 ignore next 3 */
-if (!existsSync(`./${testDabasesFolder}`)) {
-  mkdirSync(`./${testDabasesFolder}`);
-}
+export const testDatabasesFolder = `.test_dbs`;
+export const migrationsFolder = `${process.cwd()}/drizzle/migrations`;
+
 const createDatabase = () => {
   const databaseName = `${faker.string.uuid().replaceAll("-", "_")}.sqlite`;
-  const databasePath = `${process.cwd()}/${testDabasesFolder}/${databaseName}`;
+  const databasePath = `${process.cwd()}/${testDatabasesFolder}/${databaseName}`;
   const command = `echo "CREATE TABLE IF NOT EXISTS SOME_TABLE (id INTEGER PRIMARY KEY);" | sqlite3 ${databasePath}`;
   return new Promise<string>((resolve, reject) => {
     exec(command, (err, stdout, stderr) => {

--- a/src/tests/globalSetup.ts
+++ b/src/tests/globalSetup.ts
@@ -1,0 +1,13 @@
+import { existsSync, mkdirSync, unlinkSync, readdirSync } from "node:fs";
+import { testDatabasesFolder } from "./__fixtures/databaseHelper";
+
+export default () => {
+  if (!existsSync(`./${testDatabasesFolder}`)) {
+    mkdirSync(`./${testDatabasesFolder}`);
+  }
+
+  const files = readdirSync(`./${testDatabasesFolder}`);
+  for (const file of files) {
+    unlinkSync(`./${testDatabasesFolder}/${file}`);
+  }
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,9 +13,9 @@ dotenv.config({
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
+    globalSetup: "./src/tests/globalSetup.ts",
     coverage: {
       reporter: ["text", "json-summary", "json", "html"],
-      // "100": true, // TODO: Discutir con el equipo
     },
   },
 });


### PR DESCRIPTION
**Problema**
Al ejecutar yarn test sin la carpeta .test_dbs creada, ocasionalmente los tests fallaban debido a intentos concurrentes de crear la carpeta en cuestión.

<img width="1800" alt="Captura de pantalla 2023-12-12 a la(s) 00 39 47" src="https://github.com/JSConfCL/gql_api/assets/37272605/5b32e20c-6f8c-4849-84ec-fa38abc42858">

**Solución Propuesta**
Se ha movido la lógica de creación de la carpeta a un globalSetup en Vitest. Esto asegura que la carpeta se cree una sola vez antes de iniciar los tests, evitando conflictos de concurrencia.

Este cambio mejora la confiabilidad de los tests, facilitando un entorno de testing más consistente.