### PR TITLE
Limpiando solo OCs que tengan asociada una compra en stripe o mercadopago

### DIFF
--- a/src/schema/purchaseOrder/actions.tsx
+++ b/src/schema/purchaseOrder/actions.tsx
@@ -506,7 +506,8 @@ export const syncPurchaseOrderPaymentStatus = async ({
 }) => {
   logger.info("Finding purchase order:", purchaseOrderId);
   const purchaseOrder = await DB.query.purchaseOrdersSchema.findFirst({
-    where: (po, { eq }) => eq(po.id, purchaseOrderId),
+    where: (po, { eq, isNotNull }) =>
+      and(eq(po.id, purchaseOrderId), isNotNull(po.paymentPlatformReferenceID)),
   });
 
   if (!purchaseOrder) {
@@ -518,7 +519,9 @@ export const syncPurchaseOrderPaymentStatus = async ({
   logger.info("Payment platform reference id:", paymentPlatformReferenceID);
 
   if (!paymentPlatformReferenceID) {
-    throw new Error("No se ha inicializado un pago para esta OC");
+    throw new Error(
+      `No se ha inicializado un pago para la OC ${purchaseOrderId}`,
+    );
   }
 
   let poPaymentStatus: (typeof puchaseOrderPaymentStatusEnum)[number] =

--- a/workers/purchase_order_payment_sync_cron/index.ts
+++ b/workers/purchase_order_payment_sync_cron/index.ts
@@ -2,4 +2,8 @@ import { scheduled } from "./scheduled";
 
 export default {
   scheduled,
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async fetch() {
+    return new Response(".");
+  },
 };

--- a/workers/purchase_order_payment_sync_cron/scheduled.tsx
+++ b/workers/purchase_order_payment_sync_cron/scheduled.tsx
@@ -29,11 +29,17 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
   });
   const GET_STRIPE_CLIENT = () => getStripeClient(env.STRIPE_KEY);
   const GET_MERCADOPAGO_CLIENT = getMercadoPagoFetch(env.MERCADOPAGO_KEY);
+
   // Busca todas las OCs que no estén pagadas.
   logger.info(`Getting upaid purchase orders...`);
   const getUnpaidPurchaseOrders = await DB.query.purchaseOrdersSchema.findMany({
-    where: (po, { eq }) => eq(po.purchaseOrderPaymentStatus, "unpaid"),
+    where: (po, { eq, and, isNotNull }) =>
+      and(
+        eq(po.purchaseOrderPaymentStatus, "unpaid"),
+        isNotNull(po.paymentPlatformReferenceID),
+      ),
   });
+
   logger.info(
     `Obtained ${getUnpaidPurchaseOrders.length} unpaid purchase orders`,
   );

--- a/workers/purchase_order_payment_sync_cron/scheduled.tsx
+++ b/workers/purchase_order_payment_sync_cron/scheduled.tsx
@@ -33,7 +33,11 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
   // Busca todas las OCs que no estén pagadas.
   logger.info(`Getting upaid purchase orders...`);
   const getUnpaidPurchaseOrders = await DB.query.purchaseOrdersSchema.findMany({
-    where: (po, { eq }) => eq(po.purchaseOrderPaymentStatus, "unpaid"),
+    where: (po, { eq, and, isNotNull }) =>
+      and(
+        eq(po.purchaseOrderPaymentStatus, "unpaid"),
+        isNotNull(po.paymentPlatformReferenceID),
+      ),
   });
 
   logger.info(

--- a/workers/purchase_order_payment_sync_cron/scheduled.tsx
+++ b/workers/purchase_order_payment_sync_cron/scheduled.tsx
@@ -33,11 +33,7 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
   // Busca todas las OCs que no estén pagadas.
   logger.info(`Getting upaid purchase orders...`);
   const getUnpaidPurchaseOrders = await DB.query.purchaseOrdersSchema.findMany({
-    where: (po, { eq, and, isNotNull }) =>
-      and(
-        eq(po.purchaseOrderPaymentStatus, "unpaid"),
-        isNotNull(po.paymentPlatformReferenceID),
-      ),
+    where: (po, { eq }) => eq(po.purchaseOrderPaymentStatus, "unpaid"),
   });
 
   logger.info(


### PR DESCRIPTION
Cuando las ordenes son de solo entradas gratis, no las asociamos a un payment provider. PR filtra el cron de limpieza para que solo considere tickets que tengan payments providers asociados.