### PR TITLE
Adding pagination helpers so we can simplify our quering

### DIFF
--- a/src/authn/index.ts
+++ b/src/authn/index.ts
@@ -96,13 +96,15 @@ export const getUser = async ({
   if (!payload) {
     logger.error("Could not parse token");
 
-    return payload;
+    return null;
   }
 
   const verified = await verify(JWT_TOKEN, SUPABASE_JWT_DECODER);
 
   if (!verified) {
-    throw unauthorizedError("Could not verify token");
+    logger.error("Could not verify token");
+
+    return null;
   }
 
   const isExpired = payload.exp < Date.now() / 1000;

--- a/src/authn/index.ts
+++ b/src/authn/index.ts
@@ -96,15 +96,13 @@ export const getUser = async ({
   if (!payload) {
     logger.error("Could not parse token");
 
-    return null;
+    return payload;
   }
 
   const verified = await verify(JWT_TOKEN, SUPABASE_JWT_DECODER);
 
   if (!verified) {
-    logger.error("Could not verify token");
-
-    return null;
+    throw unauthorizedError("Could not verify token");
   }
 
   const isExpired = payload.exp < Date.now() / 1000;

--- a/src/datasources/helpers/paginationQuery.ts
+++ b/src/datasources/helpers/paginationQuery.ts
@@ -1,0 +1,42 @@
+import { sql } from "drizzle-orm";
+import { PgSelect } from "drizzle-orm/pg-core";
+
+import { ORM_TYPE } from "~/datasources/db";
+
+export const paginationDBHelper = async <
+  T extends { execute: (...args: any) => any },
+>(
+  DB: ORM_TYPE,
+  select: T,
+  {
+    page,
+    pageSize,
+  }: {
+    page: number;
+    pageSize: number;
+  },
+) => {
+  const query = select as unknown as PgSelect;
+  const offset = Math.max(page, 0) * pageSize;
+  const subQuery = query.as("sub");
+  const totalRecordsQuery = DB.select({
+    total: sql<number>`count(*)`,
+  }).from(subQuery);
+
+  // TODO: Considerar parallelizar estas queries en un Promise.all
+  const totalRecordsResult = await totalRecordsQuery.execute();
+  const results = await query.limit(pageSize).offset(offset).execute();
+
+  const totalRecords = Number(totalRecordsResult[0].total);
+  const totalPages = Math.ceil(totalRecords / pageSize);
+
+  return {
+    data: results as unknown as Awaited<ReturnType<T["execute"]>>,
+    pagination: {
+      totalRecords: totalRecords,
+      totalPages: totalPages,
+      currentPage: page,
+      pageSize: pageSize,
+    },
+  };
+};

--- a/src/schema/pagination/types.ts
+++ b/src/schema/pagination/types.ts
@@ -83,12 +83,12 @@ builder.objectType(PaginationRef, {
   }),
 });
 
-const CreatePaginationRef = <TShape>(name: string) => {
+const CreatePaginationRef = <T>(name: string) => {
   const capitalizedName = capitalizeFirstLetter(name);
 
   return builder.objectRef<{
     pagination: PaginationResponseType;
-    data: TShape[];
+    data: T[];
   }>(`Paginated${capitalizedName}`);
 };
 
@@ -111,12 +111,11 @@ export const createPaginationInputType = <
 };
 
 export const createPaginationObjectType = <
-  T extends ImplementableObjectRef<any, TShape>,
-  TShape
+  T extends ImplementableObjectRef<any, any>,
 >(
   objectReference: T,
 ) => {
-  const ref = CreatePaginationRef<TShape>(objectReference["name"]);
+  const ref = CreatePaginationRef<T>(objectReference["name"]);
 
   builder.objectType(ref, {
     description:

--- a/src/schema/pagination/types.ts
+++ b/src/schema/pagination/types.ts
@@ -83,12 +83,12 @@ builder.objectType(PaginationRef, {
   }),
 });
 
-const CreatePaginationRef = <T>(name: string) => {
+const CreatePaginationRef = <TShape>(name: string) => {
   const capitalizedName = capitalizeFirstLetter(name);
 
   return builder.objectRef<{
     pagination: PaginationResponseType;
-    data: T[];
+    data: TShape[];
   }>(`Paginated${capitalizedName}`);
 };
 
@@ -111,11 +111,12 @@ export const createPaginationInputType = <
 };
 
 export const createPaginationObjectType = <
-  T extends ImplementableObjectRef<any, any>,
+  T extends ImplementableObjectRef<any, TShape>,
+  TShape
 >(
   objectReference: T,
 ) => {
-  const ref = CreatePaginationRef<T>(objectReference["name"]);
+  const ref = CreatePaginationRef<TShape>(objectReference["name"]);
 
   builder.objectType(ref, {
     description:

--- a/src/schema/pagination/types.ts
+++ b/src/schema/pagination/types.ts
@@ -1,8 +1,6 @@
 import {
   ImplementableObjectRef,
-  InputFieldRef,
   InputObjectRef,
-  ObjectRef,
   QueryFieldBuilder,
 } from "@pothos/core";
 
@@ -112,7 +110,7 @@ export const createPaginationInputType = <
 
 export const createPaginationObjectType = <
   T extends ImplementableObjectRef<any, TShape>,
-  TShape
+  TShape,
 >(
   objectReference: T,
 ) => {

--- a/src/schema/pagination/types.ts
+++ b/src/schema/pagination/types.ts
@@ -1,0 +1,141 @@
+import {
+  ImplementableObjectRef,
+  InputFieldRef,
+  InputObjectRef,
+  ObjectRef,
+  QueryFieldBuilder,
+} from "@pothos/core";
+
+import { builder } from "~/builder";
+
+const capitalizeFirstLetter = (string: string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+const PaginationSearchInputParams = builder.inputType(
+  "PaginationSearchInputParams",
+  {
+    fields: (t) => ({
+      page: t.int({
+        required: true,
+        description: "Page number, starts at 0",
+      }),
+      pageSize: t.int({
+        required: true,
+      }),
+    }),
+  },
+);
+
+const createPaginationInputArg = <T extends InputObjectRef<any>>(search: T) => {
+  const capitalizedName = capitalizeFirstLetter(search.name);
+
+  return builder.inputType(`PaginatedInput${capitalizedName}`, {
+    fields: (t) => ({
+      search: t.field({
+        type: search,
+        required: false,
+      }),
+      pagination: t.field({
+        type: PaginationSearchInputParams,
+        required: true,
+        defaultValue: {
+          page: 0,
+          pageSize: 20,
+        },
+      }),
+    }),
+  });
+};
+
+type PaginationResponseType = {
+  currentPage: number;
+  pageSize: number;
+  totalRecords: number;
+  totalPages: number;
+};
+
+const PaginationRef = builder.objectRef<PaginationResponseType>("Pagination");
+
+builder.objectType(PaginationRef, {
+  description: "Pagination meta data",
+  fields: (t) => ({
+    currentPage: t.field({
+      type: "Int",
+      nullable: false,
+      resolve: (root) => root.currentPage,
+    }),
+    pageSize: t.field({
+      type: "Int",
+      nullable: false,
+      resolve: (root) => root.pageSize,
+    }),
+    totalRecords: t.field({
+      type: "Int",
+      nullable: false,
+      resolve: (root) => root.totalRecords,
+    }),
+    totalPages: t.field({
+      type: "Int",
+      nullable: false,
+      resolve: (root) => root.totalPages,
+    }),
+  }),
+});
+
+const CreatePaginationRef = <T>(name: string) => {
+  const capitalizedName = capitalizeFirstLetter(name);
+
+  return builder.objectRef<{
+    pagination: PaginationResponseType;
+    data: T[];
+  }>(`Paginated${capitalizedName}`);
+};
+
+// TODO: Considerar hacer myinputField opcional
+export const createPaginationInputType = <
+  U extends QueryFieldBuilder<any, any>,
+  T extends InputObjectRef<any>,
+>(
+  t: U,
+  myInputField: T,
+) => {
+  const newInput = createPaginationInputArg(myInputField);
+
+  return {
+    input: t.arg({
+      type: newInput,
+      required: true,
+    }),
+  };
+};
+
+export const createPaginationObjectType = <
+  T extends ImplementableObjectRef<any, any>,
+>(
+  objectReference: T,
+) => {
+  const ref = CreatePaginationRef<T>(objectReference["name"]);
+
+  builder.objectType(ref, {
+    description:
+      "Type used for querying the paginated leaves and it's paginated meta data",
+    fields: (t) => ({
+      pagination: t.field({
+        type: PaginationRef,
+        nullable: false,
+        resolve: (root) => {
+          return root.pagination;
+        },
+      }),
+      data: t.field({
+        type: [objectReference],
+        nullable: false,
+        // @ts-expect-error generics for pothos are hard to type
+        resolve: (root) => root.data ?? [],
+      }),
+    }),
+  });
+
+  return ref;
+};

--- a/src/schema/userTickets/queries.ts
+++ b/src/schema/userTickets/queries.ts
@@ -86,10 +86,11 @@ builder.queryFields((t) => ({
 
       const results = data.map((t) => selectUserTicketsSchema.parse(t));
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         data: results,
         pagination,
-      };
+      } as any;
     },
   }),
 }));

--- a/src/schema/userTickets/queries.ts
+++ b/src/schema/userTickets/queries.ts
@@ -86,11 +86,10 @@ builder.queryFields((t) => ({
 
       const results = data.map((t) => selectUserTicketsSchema.parse(t));
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return {
         data: results,
         pagination,
-      } as any;
+      };
     },
   }),
 }));


### PR DESCRIPTION
Crea: 
 - createPaginationInputType
 - createPaginationObjectType
 - paginationDBHelper

Asi podemos crear mas facilmente wrappers "paginados" para queries/objetos. 
`createPaginationInputType` y `createPaginationObjectType` nos permiten estandarizar los inputs para nuestras queries de graphql. Y nuestros outputs de respuesta (tanto en estructura como en tipos)


`paginationDBHelper` crea un helper tipado que ejecuta 2 queries, para poder retornar facilmente tanto la información de la query, como un total de records.

![image](https://github.com/JSConfCL/gql_api/assets/952992/af91fa9c-fff0-489c-a809-1df099f42a0c)
