### PR TITLE
Preventing alerts on 'Handler does not export a fetch() function' that we see in baselime

### DIFF
--- a/workers/email_queue/index.ts
+++ b/workers/email_queue/index.ts
@@ -2,4 +2,9 @@ import { queueConsumer } from "./consumer";
 
 export default {
   queue: queueConsumer,
+  fetch() {
+    return new Response(null, {
+      status: 404,
+    });
+  },
 };

--- a/workers/google_import_queue_consumer/index.ts
+++ b/workers/google_import_queue_consumer/index.ts
@@ -2,4 +2,9 @@ import { queueConsumer } from "./consumer";
 
 export default {
   queue: queueConsumer,
+  fetch() {
+    return new Response(null, {
+      status: 404,
+    });
+  },
 };

--- a/workers/purchase_order_payment_sync_cron/index.ts
+++ b/workers/purchase_order_payment_sync_cron/index.ts
@@ -2,8 +2,9 @@ import { scheduled } from "./scheduled";
 
 export default {
   scheduled,
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async fetch() {
-    return new Response(".");
+  fetch() {
+    return new Response(null, {
+      status: 404,
+    });
   },
 };

--- a/workers/sanity_asset_importer/index.ts
+++ b/workers/sanity_asset_importer/index.ts
@@ -2,4 +2,9 @@ import { scheduled } from "./scheduled";
 
 export default {
   scheduled,
+  fetch() {
+    return new Response(null, {
+      status: 404,
+    });
+  },
 };

--- a/workers/wall_of_fame_cron/index.ts
+++ b/workers/wall_of_fame_cron/index.ts
@@ -1,5 +1,12 @@
+import { P } from "pino";
+
 import { scheduled } from "./scheduled";
 
 export default {
   scheduled,
+  fetch() {
+    return new Response(null, {
+      status: 404,
+    });
+  },
 };


### PR DESCRIPTION
That's it, we have a lot of these issues, so adding a 404 response as they should not have an actual response and we have other ways to validate uptime.

![image](https://github.com/JSConfCL/gql_api/assets/952992/909a41d6-20e1-45d9-b9d5-6e39659fb5d6)
