### PR TITLE
improving miniflare and logging logic

### DIFF
--- a/migrate.ts
+++ b/migrate.ts
@@ -3,7 +3,7 @@ import { neon } from "@neondatabase/serverless";
 import { config } from "dotenv";
 
 import { runMigration } from "~/datasources/db/runMigrations";
-import { logger } from "~/logging";
+import { defaultLogger } from "~/logging";
 
 config({ path: process.cwd() + "/.dev.vars", override: true });
 
@@ -14,6 +14,6 @@ if (!process.env.NEON_URL) {
 const client = neon(process.env.NEON_URL);
 
 runMigration(client).catch((e) => {
-  logger.error(e);
+  defaultLogger.error(e);
   process.exit(1);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "uuid": "^9.0.1",
         "vite-tsconfig-paths": "^4.2.0",
         "vitest": "^0.33.0",
-        "wrangler": "^3.53.1"
+        "wrangler": "^3.65.0"
       },
       "engines": {
         "node": ">=18"
@@ -1935,9 +1935,9 @@
       "dev": true
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.2.tgz",
-      "integrity": "sha512-EeEjMobfuJrwoctj7FA1y1KEbM0+Q1xSjobIEyie9k4haVEBB7vkDvsasw1pM3rO39mL2akxIAzLMUAtrMHZhA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
       "dev": true,
       "dependencies": {
         "mime": "^3.0.0"
@@ -1946,22 +1946,10 @@
         "node": ">=16.13"
       }
     },
-    "node_modules/@cloudflare/kv-asset-handler/node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240419.0.tgz",
-      "integrity": "sha512-PGVe9sYWULHfvGhN0IZh8MsskNG/ufnBSqPbgFCxJHCTrVXLPuC35EoVaforyqjKRwj3U35XMyGo9KHcGnTeHQ==",
+      "version": "1.20240712.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240712.0.tgz",
+      "integrity": "sha512-KB1vbOhr62BCAwVr3VaRcngzPeSCQ7zPA9VGrfwYXIxo0Y4zlW1z0EVtcewFSz5XXKr3BtNnJXxdjDPUNkguQw==",
       "cpu": [
         "x64"
       ],
@@ -1975,9 +1963,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240419.0.tgz",
-      "integrity": "sha512-z4etQSPiD5Gcjs962LiC7ZdmXnN6SGof5KrYoFiSI9X9kUvpuGH/lnjVVPd+NnVNeDU2kzmcAIgyZjkjTaqVXQ==",
+      "version": "1.20240712.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240712.0.tgz",
+      "integrity": "sha512-UDwFnCfQGFVCNxOeHxKNEc1ANQk/3OIiFWpVsxgZqJqU/22XM88JHxJW+YcBKsaUGUlpLyImaYUn2/rG+i+9UQ==",
       "cpu": [
         "arm64"
       ],
@@ -1991,9 +1979,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240419.0.tgz",
-      "integrity": "sha512-lBwhg0j3sYTFMsEb4bOClbVje8nqrYOu0H3feQlX+Eks94JIhWPkf8ywK4at/BUc1comPMhCgzDHwc2OMPUGgg==",
+      "version": "1.20240712.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240712.0.tgz",
+      "integrity": "sha512-MxpMHSJcZRUL66TO7BEnEim9WgZ8wJEVOB1Rq7a/IF2hI4/8f+N+02PChh62NkBlWxDfTXAtZy0tyQMm0EGjHg==",
       "cpu": [
         "x64"
       ],
@@ -2007,9 +1995,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240419.0.tgz",
-      "integrity": "sha512-ZMY6wwWkxL+WPq8ydOp/irSYjAnMhBz1OC1+4z+OANtDs2beaZODmq7LEB3hb5WUAaTPY7DIjZh3DfDfty0nYg==",
+      "version": "1.20240712.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240712.0.tgz",
+      "integrity": "sha512-DtLYZsFFFAMgn+6YCHoQS6nYY4nbdAtcAFa4PhWTjLJDbvQEn3IoK9Bi4ajCL7xG36FeuBdZliSbBiiv7CJjfQ==",
       "cpu": [
         "arm64"
       ],
@@ -2023,9 +2011,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240419.0.tgz",
-      "integrity": "sha512-YJjgaJN2yGTkV7Cr4K3i8N4dUwVQTclT3Pr3NpRZCcLjTszwlE53++XXDnHMKGXBbSguIizaVbmcU2EtmIXyeQ==",
+      "version": "1.20240712.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240712.0.tgz",
+      "integrity": "sha512-u8zoT9PQiiwxuz9npquLBFWrC/RlBWGGZ1aylarZNFlM4sFrRm+bRr6i+KtS+fltHIVXj3teuoKYytA1ppf9Yw==",
       "cpu": [
         "x64"
       ],
@@ -10382,6 +10370,15 @@
         "url": "https://github.com/yeoman/configstore?sponsor=1"
       }
     },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -10549,6 +10546,12 @@
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true
     },
     "node_modules/dataloader": {
       "version": "2.2.2",
@@ -10904,6 +10907,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "dev": true
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -13443,12 +13452,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "node_modules/get-source/node_modules/data-uri-to-buffer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
-      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-      "dev": true
-    },
     "node_modules/get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -15680,6 +15683,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -15719,9 +15734,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20240419.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240419.0.tgz",
-      "integrity": "sha512-fIev1PP4H+fQp5FtvzHqRY2v5s+jxh/a0xAhvM5fBNXvxWX7Zod1OatXfXwYbse3hqO3KeVMhb0osVtrW0NwJg==",
+      "version": "3.20240712.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240712.0.tgz",
+      "integrity": "sha512-zVbsMX2phvJS1uTPmjK6CvVBq4ON2UkmvTw9IMfNPACsWJmHEdsBDxsYEG1vKAduJdI5gULLuJf7qpFxByDhGw==",
       "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -15731,17 +15746,38 @@
         "exit-hook": "^2.2.1",
         "glob-to-regexp": "^0.4.1",
         "stoppable": "^1.1.0",
-        "undici": "^5.28.2",
-        "workerd": "1.20240419.0",
-        "ws": "^8.11.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20240712.0",
+        "ws": "^8.17.1",
         "youch": "^3.2.2",
-        "zod": "^3.20.6"
+        "zod": "^3.22.3"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/minimatch": {
@@ -16012,6 +16048,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
+      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
+      "dev": true
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -16623,9 +16665,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.1.tgz",
-      "integrity": "sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true
     },
     "node_modules/pathval": {
@@ -20028,9 +20070,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.0.tgz",
-      "integrity": "sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
       "dev": true
     },
     "node_modules/unbox-primitive": {
@@ -20067,6 +20109,21 @@
       },
       "engines": {
         "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "1.10.0-1717606461.a117952",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-1.10.0-1717606461.a117952.tgz",
+      "integrity": "sha512-u3TfBX02WzbHTpaEfWEKwDijDSFAHcgXkayUZ+MVDrjhLFvgAJzFGTSTmwlEhwWi2exyRQey23ah9wELMM6etg==",
+      "dev": true,
+      "dependencies": {
+        "consola": "^3.2.3",
+        "defu": "^6.1.4",
+        "mime": "^3.0.0",
+        "node-fetch-native": "^1.6.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.3"
       }
     },
     "node_modules/unique-string": {
@@ -20711,9 +20768,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20240419.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240419.0.tgz",
-      "integrity": "sha512-9yV98KpkQgG+bdEsKEW8i1AYZgxns6NVSfdOVEB2Ue1pTMtIEYfUyqUE+O2amisRrfaC3Pw4EvjtTmVaoetfeg==",
+      "version": "1.20240712.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240712.0.tgz",
+      "integrity": "sha512-hdIHZif82hBDy9YnMtcmDGgbLU5f2P2aGpi/X8EKhTSLDppVUGrkY3XB536J4jGjA2D5dS0FUEXCl5bAJEed8Q==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -20723,32 +20780,34 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20240419.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20240419.0",
-        "@cloudflare/workerd-linux-64": "1.20240419.0",
-        "@cloudflare/workerd-linux-arm64": "1.20240419.0",
-        "@cloudflare/workerd-windows-64": "1.20240419.0"
+        "@cloudflare/workerd-darwin-64": "1.20240712.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20240712.0",
+        "@cloudflare/workerd-linux-64": "1.20240712.0",
+        "@cloudflare/workerd-linux-arm64": "1.20240712.0",
+        "@cloudflare/workerd-windows-64": "1.20240712.0"
       }
     },
     "node_modules/wrangler": {
-      "version": "3.53.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.53.1.tgz",
-      "integrity": "sha512-bdMRQdHYdvowIwOhEMFkARIZUh56aDw7HLUZ/2JreBjj760osXE4Fc4L1TCkfRRBWgB6/LKF5LA4OcvORMYmHg==",
+      "version": "3.65.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.65.0.tgz",
+      "integrity": "sha512-IDy4ttyJZssazAd5CXHw4NWeZFGxngdNF5m2ogltdT3CV7uHfCvPVdMcr4uNMpRZd0toHmAE3LtQeXxDFFp88A==",
       "dev": true,
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.3.2",
+        "@cloudflare/kv-asset-handler": "0.3.4",
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
+        "date-fns": "^3.6.0",
         "esbuild": "0.17.19",
-        "miniflare": "3.20240419.0",
+        "miniflare": "3.20240712.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "resolve": "^1.22.8",
         "resolve.exports": "^2.0.2",
         "selfsigned": "^2.0.1",
-        "source-map": "0.6.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@1.10.0-1717606461.a117952",
         "xxhash-wasm": "^1.0.1"
       },
       "bin": {
@@ -20762,7 +20821,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20240419.0"
+        "@cloudflare/workers-types": "^4.20240712.0"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -21357,9 +21416,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "uuid": "^9.0.1",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.33.0",
-    "wrangler": "^3.53.1"
+    "wrangler": "^3.65.0"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettier:ci": "prettier ./src --cache --check",
     "prettier:fix": "prettier ./src --cache --write",
     "typecheck": "tsc",
-    "dev": "wrangler dev --compatibility-date 2022-11-30 --log-level info --port 50123",
+    "dev": "wrangler dev --log-level info --port 50123",
     "dev:wall-of-fame": "wrangler dev --test-scheduled --config ./workers/wall_of_fame_cron/wrangler.toml",
     "dev:sanity": "wrangler dev --test-scheduled --config ./workers/sanity_asset_importer/wrangler.toml",
     "dev:auth": "wrangler dev --test-scheduled --config ./workers/auth_tokens/wrangler.toml",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,6 +5,7 @@ import TracingPlugin, { wrapResolver } from "@pothos/plugin-tracing";
 import { DateResolver, DateTimeResolver } from "graphql-scalars";
 
 import * as rules from "~/authz";
+import { defaultLogger } from "~/logging";
 import { Context } from "~/types";
 
 export const builder = new SchemaBuilder<{
@@ -26,10 +27,9 @@ export const builder = new SchemaBuilder<{
     default: () => true,
     wrap: (resolver, options, config) =>
       wrapResolver(resolver, (error, duration) => {
-        // eslint-disable-next-line no-console
-        // console.debug(
-        //   `[TRACING] ${config.parentType}.${config.name} in ${duration}ms`,
-        // );
+        defaultLogger.debug(
+          `[TRACING] ${config.parentType}.${config.name} in ${duration}ms`,
+        );
       }),
   },
 });

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,7 +5,6 @@ import TracingPlugin, { wrapResolver } from "@pothos/plugin-tracing";
 import { DateResolver, DateTimeResolver } from "graphql-scalars";
 
 import * as rules from "~/authz";
-import { logger } from "~/logging";
 import { Context } from "~/types";
 
 export const builder = new SchemaBuilder<{
@@ -27,9 +26,10 @@ export const builder = new SchemaBuilder<{
     default: () => true,
     wrap: (resolver, options, config) =>
       wrapResolver(resolver, (error, duration) => {
-        logger.debug(
-          `[TRACING] ${config.parentType}.${config.name} in ${duration}ms`,
-        );
+        // eslint-disable-next-line no-console
+        // console.debug(
+        //   `[TRACING] ${config.parentType}.${config.name} in ${duration}ms`,
+        // );
       }),
   },
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -114,7 +114,7 @@ export const creageGraphqlContext = async ({
   });
 
   return {
-    ...initContextCache(),
+    // ...initContextCache(),
     DB,
     USER,
     ORIGINAL_USER,

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,7 +12,7 @@ import { getStripeClient } from "~/datasources/stripe/client";
 import { APP_ENV } from "~/env";
 import { Context } from "~/types";
 
-export const creageGraphqlContext = async ({
+export const createGraphqlContext = async ({
   request,
   NEON_URL,
   PURCHASE_CALLBACK_URL,
@@ -114,7 +114,7 @@ export const creageGraphqlContext = async ({
   });
 
   return {
-    // ...initContextCache(),
+    ...initContextCache(),
     DB,
     USER,
     ORIGINAL_USER,

--- a/src/datasources/db/index.ts
+++ b/src/datasources/db/index.ts
@@ -6,8 +6,7 @@ import {
 } from "drizzle-orm/node-postgres";
 import { PgTransaction } from "drizzle-orm/pg-core";
 import { Client } from "pg";
-
-import { logger } from "~/logging";
+import { Logger } from "pino";
 
 import * as schema from "./schema";
 
@@ -18,7 +17,13 @@ export type TRANSACTION_HANDLER = PgTransaction<
   ExtractTablesWithRelations<typeof schema>
 >;
 
-export const getDb = async ({ neonUrl }: { neonUrl: string }) => {
+export const getDb = async ({
+  neonUrl,
+  logger,
+}: {
+  neonUrl: string;
+  logger: Logger<never>;
+}) => {
   const client = new Client({
     connectionString: neonUrl,
   });
@@ -27,11 +32,11 @@ export const getDb = async ({ neonUrl }: { neonUrl: string }) => {
     await client.connect();
     const db = drizzle(client, {
       schema,
-      logger: {
-        logQuery(query, params) {
-          logger.info(query, params);
-        },
-      },
+      // logger: {
+      //   logQuery(query, params) {
+      //     logger.info(query, params);
+      //   },
+      // },
     });
 
     return db;

--- a/src/datasources/email/sendEmailToWorkers.ts
+++ b/src/datasources/email/sendEmailToWorkers.ts
@@ -1,13 +1,13 @@
 import { backOff } from "exponential-backoff";
+import { Logger } from "pino";
 import type { Resend } from "resend";
-
-import { logger } from "~/logging";
 
 const numOfAttempts = 5; // Maximum number of retries
 const delay = 1000; // Initial delay in milliseconds
 
 export async function sendTransactionalHTMLEmail(
   resend: Resend,
+  logger: Logger<never>,
   {
     htmlContent,
     to,

--- a/src/datasources/mercadopago/index.ts
+++ b/src/datasources/mercadopago/index.ts
@@ -2,6 +2,7 @@ import { Items } from "mercadopago/dist/clients/commonTypes";
 import { PaymentResponse } from "mercadopago/dist/clients/payment/commonTypes";
 import { PreferenceResponse } from "mercadopago/dist/clients/preference/commonTypes";
 import { PreferenceCreateData } from "mercadopago/dist/clients/preference/create/types";
+import { Logger } from "pino";
 
 import {
   puchaseOrderPaymentStatusEnum,
@@ -11,7 +12,6 @@ import {
   someMinutesIntoTheFuture,
   toISOStringWithTimezone,
 } from "~/datasources/helpers";
-import { logger } from "~/logging";
 
 const getPaymentStatusFromMercadoPago = (
   mercadoPagoStatus: PaymentResponse["status"],
@@ -70,7 +70,7 @@ const getPurchasOrderStatusFromMercadoPago = (
 };
 
 export const getMercadoPagoFetch =
-  (token: string) =>
+  (token: string, logger: Logger<never>) =>
   async <T>({
     url,
     method = "GET",
@@ -157,9 +157,11 @@ export const createMercadoPagoPayment = async ({
 export const getMercadoPagoPreference = async ({
   preferenceId,
   getMercadoPagoClient,
+  logger,
 }: {
   preferenceId: string;
   getMercadoPagoClient: MercadoPagoFetch;
+  logger: Logger<never>;
 }) => {
   const preference = await getMercadoPagoClient<PreferenceResponse>({
     url: `/checkout/preferences/${preferenceId}`,

--- a/src/datasources/queries/users.ts
+++ b/src/datasources/queries/users.ts
@@ -1,4 +1,5 @@
 import { eq, sql } from "drizzle-orm";
+import { Logger } from "pino";
 import { z } from "zod";
 
 import { ORM_TYPE } from "~/datasources/db";
@@ -8,7 +9,6 @@ import {
   usersSchema,
 } from "~/datasources/db/schema";
 import { getUsername } from "~/datasources/queries/utils/createUsername";
-import { logger } from "~/logging";
 
 export const findUserByID = async (db: ORM_TYPE, id: string) => {
   const result = await db.query.usersSchema.findFirst({
@@ -21,6 +21,7 @@ export const findUserByID = async (db: ORM_TYPE, id: string) => {
 export const updateUserProfileInfo = async (
   db: ORM_TYPE,
   parsedProfileInfo: z.infer<typeof insertUsersSchema>,
+  logger: Logger<never>,
 ) => {
   const result = await db.query.usersSchema.findFirst({
     where: (u, { eq }) => eq(u.email, parsedProfileInfo.email),

--- a/src/datasources/queues/mail/index.ts
+++ b/src/datasources/queues/mail/index.ts
@@ -1,4 +1,4 @@
-import { logger } from "~/logging";
+import { Logger } from "pino";
 
 import { Env } from "../../../../worker-configuration";
 
@@ -9,6 +9,7 @@ export type EmailMessageType = {
 };
 export const enqueueEmail = (
   MAIL_QUEUE: Queue,
+  logger: Logger<never>,
   emailMessage: EmailMessageType,
 ) => {
   logger.info("Enqueuing email", emailMessage, "to the queue: ", MAIL_QUEUE);

--- a/src/datasources/queues/mail/mail.test.ts
+++ b/src/datasources/queues/mail/mail.test.ts
@@ -11,10 +11,19 @@ describe("Test email library", () => {
       const mockedQueue = {
         send: spy,
       };
+      const mockedLogger = {
+        info: vi.fn().mockImplementation(() => {
+          // do nothing
+        }),
+        debug: vi.fn().mockImplementation(() => {
+          // do nothing
+        }),
+      };
 
       await enqueueEmail(
         // @ts-expect-error Estamos mockeando la cola de cloudflare
         mockedQueue,
+        mockedLogger,
         {
           code: "123",
           userId: "123",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,7 @@
 import { createGraphQLError } from "graphql-yoga";
+import { Logger } from "pino";
 
 import { builder } from "~/builder";
-import { logger } from "~/logging";
 
 enum ServiceErrors {
   UNAUTHENTICATED = "UNAUTHENTICATED",
@@ -18,6 +18,7 @@ const error_codes = {
 export const applicationError = (
   message: string,
   errorType: ServiceErrors,
+  logger: Logger<never>,
   options?: Parameters<typeof createGraphQLError>[1],
 ) => {
   logger.error(`Service error: ${errorType}: ${message}`);
@@ -33,8 +34,9 @@ export const applicationError = (
 
 export const unauthorizedError = (
   message: string,
+  logger: Logger<never>,
   options?: Parameters<typeof createGraphQLError>[1],
 ) =>
-  applicationError(message, ServiceErrors.UNAUTHENTICATED, {
+  applicationError(message, ServiceErrors.UNAUTHENTICATED, logger, {
     ...options,
   });

--- a/src/generated/generate.ts
+++ b/src/generated/generate.ts
@@ -5,7 +5,7 @@ import {
   printSchema,
 } from "graphql/utilities";
 
-import { logger } from "~/logging";
+import { defaultLogger } from "~/logging";
 import { schema } from "~/schema";
 
 const start = async () => {
@@ -14,4 +14,4 @@ const start = async () => {
   await writeFile("./src/generated/schema.gql", schemaString, "utf-8");
 };
 
-start().catch(logger.error);
+start().catch(defaultLogger.error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createYoga, maskError } from "graphql-yoga";
 import { Env } from "worker-configuration";
 import { logPossibleUserIdFromJWT, logTraceId } from "~/authn";
 import * as rules from "~/authz";
-import { creageGraphqlContext } from "~/context";
+import { createGraphqlContext } from "~/context";
 import { APP_ENV } from "~/env";
 import { createLogger } from "~/logging";
 import { schema } from "~/schema";
@@ -66,7 +66,7 @@ export const yoga = createYoga<Env>({
     useImmediateIntrospection(),
     authZEnvelopPlugin({ rules }),
   ].filter(Boolean),
-  context: creageGraphqlContext,
+  context: createGraphqlContext,
 });
 
 export default {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,6 @@
 import { pino } from "pino";
 
-const defaultLogger = pino({
+export const defaultLogger = pino({
   browser: {
     asObject: true,
   },

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -9,8 +9,12 @@ const defaultLogger = pino({
   },
 });
 
-export const logger = defaultLogger;
-
-export const createLogger = (name: string) => {
-  return defaultLogger.child({ loggerName: name });
+export const createLogger = (
+  name: string,
+  params: { [key in string]: string | number | undefined | null } = {},
+) => {
+  return defaultLogger.child({
+    loggerName: name,
+    ...params,
+  });
 };

--- a/src/schema/events/types.ts
+++ b/src/schema/events/types.ts
@@ -38,7 +38,7 @@ export const eventVisibility = ["public", "private", "unlisted"] as const;
 export const EventVisibility = builder.enumType("EventVisibility", {
   values: eventVisibility,
 });
-const AdminRoles = new Set(["admin", "collaborator"]);
+// const AdminRoles = new Set(["admin", "collaborator"]);
 
 const EventsTicketsSearchInput = builder.inputType("EventsTicketsSearchInput", {
   fields: (t) => ({

--- a/src/schema/purchaseOrder/mutations.tsx
+++ b/src/schema/purchaseOrder/mutations.tsx
@@ -41,6 +41,7 @@ builder.mutationField("payForPurchaseOrder", (t) =>
         PURCHASE_CALLBACK_URL,
         GET_MERCADOPAGO_CLIENT,
         RESEND,
+        logger,
       },
     ) => {
       if (!USER) {
@@ -58,6 +59,7 @@ builder.mutationField("payForPurchaseOrder", (t) =>
         PURCHASE_CALLBACK_URL,
         GET_MERCADOPAGO_CLIENT,
         currencyId: currencyID,
+        logger,
       });
 
       // 4. We return the payment link.
@@ -97,7 +99,7 @@ builder.mutationField("checkPurchaseOrderStatus", (t) =>
     resolve: async (
       parent,
       { input },
-      { DB, GET_STRIPE_CLIENT, GET_MERCADOPAGO_CLIENT, USER },
+      { DB, GET_STRIPE_CLIENT, GET_MERCADOPAGO_CLIENT, USER, logger },
     ) => {
       if (!USER) {
         throw new Error("User is required");
@@ -119,6 +121,7 @@ builder.mutationField("checkPurchaseOrderStatus", (t) =>
         purchaseOrderId,
         GET_STRIPE_CLIENT,
         GET_MERCADOPAGO_CLIENT,
+        logger,
       });
 
       const tickets = await DB.query.userTicketsSchema.findMany({

--- a/src/schema/tags/queries.ts
+++ b/src/schema/tags/queries.ts
@@ -22,6 +22,7 @@ builder.queryFields((t) => ({
       input: t.arg({ type: TagSearchInput, required: false }),
     },
     resolve: async (root, args, ctx) => {
+      const { logger } = ctx;
       const { id, name, description } = args.input || {};
       const wheres: SQL[] = [];
 

--- a/src/schema/tags/queries.ts
+++ b/src/schema/tags/queries.ts
@@ -2,7 +2,6 @@ import { SQL, eq, ilike } from "drizzle-orm";
 
 import { builder } from "~/builder";
 import { selectTagsSchema, tagsSchema } from "~/datasources/db/schema";
-import { logger } from "~/logging";
 import { sanitizeForLikeSearch } from "~/schema/shared/helpers";
 import { TagRef } from "~/schema/shared/refs";
 

--- a/src/schema/tags/queries.ts
+++ b/src/schema/tags/queries.ts
@@ -20,8 +20,7 @@ builder.queryFields((t) => ({
     args: {
       input: t.arg({ type: TagSearchInput, required: false }),
     },
-    resolve: async (root, args, ctx) => {
-      const { logger } = ctx;
+    resolve: async (root, args, { logger, DB }) => {
       const { id, name, description } = args.input || {};
       const wheres: SQL[] = [];
 
@@ -39,7 +38,7 @@ builder.queryFields((t) => ({
         );
       }
 
-      const query = ctx.DB.query.tagsSchema.findMany({
+      const query = DB.query.tagsSchema.findMany({
         where: (c, { and }) => and(...wheres),
         orderBy(fields, operators) {
           return operators.asc(fields.createdAt);

--- a/src/schema/ticket/helpers.ts
+++ b/src/schema/ticket/helpers.ts
@@ -1,10 +1,10 @@
 import { eq } from "drizzle-orm";
+import { Logger } from "pino";
 import Stripe from "stripe";
 
 import { TRANSACTION_HANDLER } from "~/datasources/db";
 import { selectTicketSchema, ticketsSchema } from "~/datasources/db/schema";
 import { createStripeProductAndPrice } from "~/datasources/stripe";
-import { logger } from "~/logging";
 
 export const ensureProductsAreCreated = async ({
   price,
@@ -12,12 +12,14 @@ export const ensureProductsAreCreated = async ({
   getStripeClient,
   ticket,
   transactionHander,
+  logger,
 }: {
   price: number;
   currencyCode: string;
   ticket: typeof selectTicketSchema._type;
   getStripeClient: () => Stripe;
   transactionHander: TRANSACTION_HANDLER;
+  logger: Logger<never>;
 }) => {
   if (currencyCode === "USD") {
     const stripeProductId = await createStripeProductAndPrice({

--- a/src/schema/ticket/mutations.ts
+++ b/src/schema/ticket/mutations.ts
@@ -99,7 +99,7 @@ builder.mutationField("createTicket", (t) =>
       rules: ["IsAuthenticated"],
     },
     resolve: async (root, { input }, ctx) => {
-      const logger = ctx.logger
+      const logger = ctx.logger;
 
       if (!ctx.USER) {
         throw new GraphQLError("User not found");
@@ -277,6 +277,7 @@ builder.mutationField("createTicket", (t) =>
                 ticket: insertedTicket,
                 getStripeClient: ctx.GET_STRIPE_CLIENT,
                 transactionHander: trx,
+                logger,
               });
             }
           }

--- a/src/schema/ticket/mutations.ts
+++ b/src/schema/ticket/mutations.ts
@@ -357,15 +357,15 @@ builder.mutationField("editTicket", (t) =>
     authz: {
       rules: ["IsAuthenticated"],
     },
-    resolve: async (root, { input }, ctx) => {
+    resolve: async (root, { input }, { logger, USER, DB }) => {
       try {
         const { ticketId } = input;
 
-        if (!ctx.USER) {
+        if (!USER) {
           throw new GraphQLError("User not found");
         }
 
-        if (!(await canEditTicket(ctx.USER.id, ticketId, ctx.DB))) {
+        if (!(await canEditTicket(USER.id, ticketId, DB))) {
           throw new GraphQLError("Not authorized");
         }
 
@@ -410,7 +410,7 @@ builder.mutationField("editTicket", (t) =>
 
         if (response.success) {
           const ticket = (
-            await ctx.DB.update(ticketsSchema)
+            await DB.update(ticketsSchema)
               .set(response.data)
               .where(eq(ticketsSchema.id, ticketId))
               .returning()

--- a/src/schema/ticket/mutations.ts
+++ b/src/schema/ticket/mutations.ts
@@ -13,7 +13,6 @@ import {
   ticketsSchema,
   updateTicketSchema,
 } from "~/datasources/db/schema";
-import { logger } from "~/logging";
 import { addToObjectIfPropertyExists } from "~/schema/shared/helpers";
 import { TicketRef } from "~/schema/shared/refs";
 import { ensureProductsAreCreated } from "~/schema/ticket/helpers";
@@ -100,6 +99,8 @@ builder.mutationField("createTicket", (t) =>
       rules: ["IsAuthenticated"],
     },
     resolve: async (root, { input }, ctx) => {
+      const logger = ctx.logger
+
       if (!ctx.USER) {
         throw new GraphQLError("User not found");
       }

--- a/src/schema/user/userFetcher.ts
+++ b/src/schema/user/userFetcher.ts
@@ -1,4 +1,4 @@
-import { SQL, and, asc, eq, ilike, inArray, or } from "drizzle-orm";
+import { SQL, and, asc, ilike, inArray, or } from "drizzle-orm";
 
 import { ORM_TYPE } from "~/datasources/db";
 import {

--- a/src/schema/userTickets/mutations.ts
+++ b/src/schema/userTickets/mutations.ts
@@ -471,6 +471,7 @@ builder.mutationFields((t) => ({
                 PURCHASE_CALLBACK_URL,
                 GET_MERCADOPAGO_CLIENT,
                 currencyId: generatePaymentLink.currencyId,
+                logger,
               });
               const tickets = await trx.query.userTicketsSchema.findMany({
                 where: (uts, { inArray }) => inArray(uts.id, ticketsIds),

--- a/src/schema/userTickets/mutations.ts
+++ b/src/schema/userTickets/mutations.ts
@@ -9,7 +9,6 @@ import {
   selectUserTicketsSchema,
   userTicketsSchema,
 } from "~/datasources/db/schema";
-import { logger } from "~/logging";
 import { PurchaseOrderRef } from "~/schema/purchaseOrder/types";
 import { isValidUUID } from "~/schema/shared/helpers";
 import { UserTicketRef } from "~/schema/shared/refs";
@@ -263,6 +262,7 @@ builder.mutationFields((t) => ({
         GET_STRIPE_CLIENT,
         PURCHASE_CALLBACK_URL,
         GET_MERCADOPAGO_CLIENT,
+        logger,
       },
     ) => {
       if (!USER) {

--- a/src/tests/fixtures/index.ts
+++ b/src/tests/fixtures/index.ts
@@ -90,6 +90,7 @@ import {
   TicketPaymentStatus,
   TicketRedemptionStatus,
 } from "~/generated/types";
+import { defaultLogger } from "~/logging";
 import { schema } from "~/schema";
 import { getTestDB } from "~/tests/fixtures/databaseHelper";
 
@@ -123,6 +124,7 @@ const createExecutor = (user?: Awaited<ReturnType<typeof insertUser>>) =>
         return {
           ...initContextCache(),
           DB,
+          logger: defaultLogger,
           USER: user ? user : undefined,
           GET_STRIPE_CLIENT: () => null,
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import pino from "pino";
 import { Resend } from "resend";
 
 import { Env } from "worker-configuration";
@@ -9,6 +10,7 @@ import { getStripeClient } from "~/datasources/stripe/client";
 
 export type Context = {
   DB: ORM_TYPE;
+  logger: pino.Logger<never>;
   GET_SANITY_CLIENT: () => ReturnType<typeof getSanityClient>;
   GET_STRIPE_CLIENT: () => ReturnType<typeof getStripeClient>;
   GET_MERCADOPAGO_CLIENT: MercadoPagoFetch;

--- a/workers/auth_tokens/index.ts
+++ b/workers/auth_tokens/index.ts
@@ -1,17 +1,27 @@
 import { Hono } from "hono";
 import { google, SocialProvider } from "worker-auth-providers";
 
-import { logger } from "~/logging";
+import { createLogger } from "~/logging";
 
 import { ENV } from "./types";
 
 type HONO_ENV = {
   Bindings: ENV;
+  Variables: {
+    logger: ReturnType<typeof createLogger>;
+  };
 };
 
 const app = new Hono<HONO_ENV>();
 
+app.use(async (c, next) => {
+  c.set("logger", createLogger("email_webhook"));
+  await next();
+});
+
 app.get("/auth/google", async (c) => {
+  const logger = c.get("logger");
+
   try {
     const { GOOGLE_CLIENT_ID, GOOGLE_REDIRECT_URL, GOOGLE_CLIENT_SECRET } =
       c.env;

--- a/workers/email_queue/consumer.tsx
+++ b/workers/email_queue/consumer.tsx
@@ -5,7 +5,7 @@ import { WorkEmailValidationEmail } from "emails/templates/salaries/invite-email
 import { sendTransactionalHTMLEmail } from "~/datasources/email/sendEmailToWorkers";
 import { EmailMessageType } from "~/datasources/queues/mail";
 import { APP_ENV } from "~/env";
-import { logger } from "~/logging";
+import { defaultLogger } from "~/logging";
 
 type ENV = {
   RESEND_API_KEY?: string;
@@ -17,7 +17,7 @@ export const queueConsumer: ExportedHandlerQueueHandler<
   EmailMessageType
 > = async (batch, env, ctx) => {
   for await (const msg of batch.messages) {
-    logger.info("Processing email for userId:", msg.body.userId);
+    defaultLogger.info("Processing email for userId:", msg.body.userId);
 
     try {
       switch (batch.queue) {
@@ -29,7 +29,7 @@ export const queueConsumer: ExportedHandlerQueueHandler<
           throw new Error(`Unknown queue ${batch.queue}`);
       }
     } catch (e) {
-      logger.error("Error processing message", e);
+      defaultLogger.error("Error processing message", e);
       msg.retry();
     }
   }

--- a/workers/email_webhook/emailrouter.tsx
+++ b/workers/email_webhook/emailrouter.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-case-declarations */
 import { renderAsync } from "@react-email/render";
+import { Logger } from "pino";
 import React from "react";
 import type { Resend } from "resend";
 
@@ -24,10 +25,12 @@ export const mailRouter = async ({
   emailTemplate,
   body,
   resend,
+  logger,
 }: {
   emailTemplate: string;
   body: unknown;
   resend: Resend;
+  logger: Logger<never>;
 }) => {
   if (emailTemplate === "ia-camp-waitlist") {
     const {
@@ -44,7 +47,7 @@ export const mailRouter = async ({
 
     const htmlContent = await renderAsync(<IACampWaitlist nombre={nombre} />);
 
-    return sendTransactionalHTMLEmail(resend, {
+    return sendTransactionalHTMLEmail(resend, logger, {
       htmlContent,
       from: {
         name: "IACamp - by CommunityOS",
@@ -72,7 +75,7 @@ export const mailRouter = async ({
 
     const htmlContent = await renderAsync(<SponsorsConfirmation />);
 
-    return sendTransactionalHTMLEmail(resend, {
+    return sendTransactionalHTMLEmail(resend, logger, {
       htmlContent,
       from: {
         name: "IACamp - by CommunityOS",
@@ -102,7 +105,7 @@ export const mailRouter = async ({
       <AIHackathonPostulationWithTeamEmail name={name || ""} />,
     );
 
-    return sendTransactionalHTMLEmail(resend, {
+    return sendTransactionalHTMLEmail(resend, logger, {
       htmlContent,
       from: {
         name: "AI Hackathon - by CommunityOS",
@@ -132,7 +135,7 @@ export const mailRouter = async ({
       <AIHackathonPostulationWithoutTeamEmail name={name || ""} />,
     );
 
-    return sendTransactionalHTMLEmail(resend, {
+    return sendTransactionalHTMLEmail(resend, logger, {
       htmlContent,
       from: {
         name: "AI Hackathon - by CommunityOS",

--- a/workers/sanity_asset_importer/importSanity.ts
+++ b/workers/sanity_asset_importer/importSanity.ts
@@ -1,16 +1,18 @@
+import { Logger } from "pino";
+
 import { getDb } from "~/datasources/db";
 import { eventsSchema } from "~/datasources/db/events";
 import { eventsToCommunitiesSchema } from "~/datasources/db/eventsCommunities";
 import { getSanityClient } from "~/datasources/sanity/client";
 import { SanityEvent } from "~/datasources/sanity/types";
-import { logger } from "~/logging";
 
 import { ENV } from "./types";
 
-export const importFromSanity = async (env: ENV) => {
+export const importFromSanity = async (env: ENV, logger: Logger<never>) => {
   try {
     const DB = await getDb({
       neonUrl: env.NEON_URL,
+      logger,
     });
 
     const sanityClient = getSanityClient({

--- a/workers/sanity_asset_importer/scheduled.tsx
+++ b/workers/sanity_asset_importer/scheduled.tsx
@@ -1,5 +1,4 @@
-import { APP_ENV } from "~/env";
-import { logger } from "~/logging";
+import { createLogger } from "~/logging";
 import { ensureKeys } from "~workers/utils";
 
 import { importFromSanity } from "./importSanity";
@@ -10,6 +9,8 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
   env,
   ctx,
 ) => {
+  const logger = createLogger("sanity_asset_importer");
+
   ensureKeys(env, [
     "SANITY_PROJECT_ID",
     "NEON_URL",
@@ -20,7 +21,7 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
   ]);
 
   try {
-    await Promise.all([importFromSanity(env)]);
+    await Promise.all([importFromSanity(env, logger)]);
   } catch (e) {
     logger.error(e);
   }

--- a/workers/wall_of_fame_cron/api.stripe.ts
+++ b/workers/wall_of_fame_cron/api.stripe.ts
@@ -5,7 +5,7 @@ import {
   insertPaymentLogsSchema,
   paymentLogsSchema,
 } from "~/datasources/db/schema";
-import { logger } from "~/logging";
+import { defaultLogger } from "~/logging";
 
 import { ENV } from "./types";
 
@@ -44,7 +44,7 @@ export const getSubscriptions = async (env: ENV) => {
 };
 
 export const syncStripePayments = async (env: ENV) => {
-  const DB = await getDb({ neonUrl: env.NEON_URL });
+  const DB = await getDb({ neonUrl: env.NEON_URL, logger: defaultLogger });
   const stripe = new Stripe(env.ST_KEY);
 
   const results = await stripe.charges.list({ limit: 100 });
@@ -70,10 +70,15 @@ const savePaymentEntry = async (DB: ORM_TYPE, results: Stripe.Charge[]) => {
       .onConflictDoNothing()
       .returning();
 
-    logger.info("👉Saved", saved.length, "financial entries from stripe", {
-      saved,
-    });
+    defaultLogger.info(
+      "👉Saved",
+      saved.length,
+      "financial entries from stripe",
+      {
+        saved,
+      },
+    );
   } catch (e) {
-    logger.error("Error saving payment entries", e);
+    defaultLogger.error("Error saving payment entries", e);
   }
 };

--- a/workers/wall_of_fame_cron/scheduled.tsx
+++ b/workers/wall_of_fame_cron/scheduled.tsx
@@ -1,5 +1,5 @@
 import { APP_ENV } from "~/env";
-import { logger } from "~/logging";
+import { createLogger } from "~/logging";
 import { ensureKeys } from "~workers/utils";
 
 import { syncMercadopagoPaymentsAndSubscriptions } from "./api.mercadopago";
@@ -11,6 +11,8 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
   env,
   ctx,
 ) => {
+  const logger = createLogger("wall_of_fame_cron");
+
   ensureKeys(env, [
     "NEON_URL",
     "MP_ACCESS_TOKEN",
@@ -20,7 +22,7 @@ export const scheduled: ExportedHandlerScheduledHandler<ENV> = async (
 
   try {
     await Promise.all([
-      syncMercadopagoPaymentsAndSubscriptions(env),
+      syncMercadopagoPaymentsAndSubscriptions(env, logger),
       syncStripePayments(env),
     ]);
   } catch (e) {


### PR DESCRIPTION
Workers hate it when you reuse a module across the site. So everything has to be scoped to the request. 
TLDR, moving logger to the context and upgrading wrangler to `3.65 `

This should help reduce (Though not eliminate) the issues we've been seeing with:
```
✘ [ERROR] Uncaught (in promise) Error: Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance. (I/O type: $_0)
```