### PR TITLE
QOL - update yoga version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "graphql": "^16.7.1",
         "graphql-config": "^5.0.2",
         "graphql-scalars": "^1.22.4",
-        "graphql-yoga": "^5.3.0",
+        "graphql-yoga": "^5.6.1",
         "hono": "^3.9.0",
         "mercadopago": "^2.0.9",
         "p-map": "^6.0.0",
@@ -4756,9 +4756,9 @@
       }
     },
     "node_modules/@graphql-yoga/subscription": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-5.0.0.tgz",
-      "integrity": "sha512-Ri7sK8hmxd/kwaEa0YT8uqQUb2wOLsmBMxI90QDyf96lzOMJRgBuNYoEkU1pSgsgmW2glceZ96sRYfaXqwVxUw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-5.0.1.tgz",
+      "integrity": "sha512-1wCB1DfAnaLzS+IdoOzELGGnx1ODEg9nzQXFh4u2j02vAnne6d+v4A7HIH9EqzVdPLoAaMKXCZUUdKs+j3z1fg==",
       "dependencies": {
         "@graphql-yoga/typed-event-target": "^3.0.0",
         "@repeaterjs/repeater": "^3.0.4",
@@ -4778,9 +4778,9 @@
       }
     },
     "node_modules/@graphql-yoga/subscription/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@graphql-yoga/typed-event-target": {
       "version": "3.0.0",
@@ -4795,9 +4795,9 @@
       }
     },
     "node_modules/@graphql-yoga/typed-event-target/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -8864,9 +8864,9 @@
       }
     },
     "node_modules/@whatwg-node/server": {
-      "version": "0.9.32",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.32.tgz",
-      "integrity": "sha512-PRTRE8ZhObwYx9yRoUdxYkrhCoDk2vyDA5BtaG+NAqEmU1wwbwlXUpaeRRrPuGaM7ScbIkueU25A0GJIRQzccw==",
+      "version": "0.9.36",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.36.tgz",
+      "integrity": "sha512-KT9qKLmbuWSuFv0Vg4JyK2vN2+vSuQPeEa25xpndYFROAIZntYe7e2BlWAk9l7IrgnV+M4bCVhjrAwwRsaCeiA==",
       "dependencies": {
         "@whatwg-node/fetch": "^0.9.17",
         "tslib": "^2.3.1"
@@ -8884,9 +8884,9 @@
       }
     },
     "node_modules/@whatwg-node/server/node_modules/@whatwg-node/fetch": {
-      "version": "0.9.17",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.17.tgz",
-      "integrity": "sha512-TDYP3CpCrxwxpiNY0UMNf096H5Ihf67BK1iKGegQl5u9SlpEDYrvnV71gWBGJm+Xm31qOy8ATgma9rm8Pe7/5Q==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+      "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
       "dependencies": {
         "@whatwg-node/node-fetch": "^0.5.7",
         "urlpattern-polyfill": "^10.0.0"
@@ -8896,9 +8896,9 @@
       }
     },
     "node_modules/@whatwg-node/server/node_modules/@whatwg-node/node-fetch": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.10.tgz",
-      "integrity": "sha512-KIAHepie/T1PRkUfze4t+bPlyvpxlWiXTPtcGlbIZ0vWkBJMdRmCg4ZrJ2y4XaO1eTPo1HlWYUuj1WvoIpumqg==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+      "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
       "dependencies": {
         "@kamilkisiela/fast-url-parser": "^1.1.4",
         "@whatwg-node/events": "^0.1.0",
@@ -13865,18 +13865,18 @@
       }
     },
     "node_modules/graphql-yoga": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-5.3.0.tgz",
-      "integrity": "sha512-6mXoGE5AMN6YNugJvjBFIQ0dFUiOMloN0dAzLL8GFt4iJ5WlWRgjdzGHod2zZz7yWQokEVD42DHgrc7NY3Dm0w==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-5.6.1.tgz",
+      "integrity": "sha512-eYWxCLP/qykU/zrmuMtGTZW9J2FTRZzGfaJuYieV3ATbZCfUr2se7OtsK6cm1k3QJQwx9ty87q1GjpxjBOdR3Q==",
       "dependencies": {
         "@envelop/core": "^5.0.0",
         "@graphql-tools/executor": "^1.2.5",
         "@graphql-tools/schema": "^10.0.0",
         "@graphql-tools/utils": "^10.1.0",
         "@graphql-yoga/logger": "^2.0.0",
-        "@graphql-yoga/subscription": "^5.0.0",
+        "@graphql-yoga/subscription": "^5.0.1",
         "@whatwg-node/fetch": "^0.9.17",
-        "@whatwg-node/server": "^0.9.32",
+        "@whatwg-node/server": "^0.9.36",
         "dset": "^3.1.1",
         "lru-cache": "^10.0.0",
         "tslib": "^2.5.2"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "graphql": "^16.7.1",
     "graphql-config": "^5.0.2",
     "graphql-scalars": "^1.22.4",
-    "graphql-yoga": "^5.3.0",
+    "graphql-yoga": "^5.6.1",
     "hono": "^3.9.0",
     "mercadopago": "^2.0.9",
     "p-map": "^6.0.0",

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,7 @@ import { getStripeClient } from "~/datasources/stripe/client";
 import { APP_ENV } from "~/env";
 import { Context } from "~/types";
 
+//
 export const createGraphqlContext = async ({
   request,
   NEON_URL,


### PR DESCRIPTION
Looking at the changelogs, https://the-guild.dev/graphql/yoga-server/changelog#531 the next **minor** version of what we are using has this change: 

> [#3197](https://github.com/dotansimha/graphql-yoga/pull/3197) [f775b341](https://github.com/dotansimha/graphql-yoga/commit/f775b341729145cee68747ab966aa9f4a9ea0389) Thanks [@n1ru4l](https://github.com/n1ru4l)! - Experimental support for aborting GraphQL execution when the HTTP request is canceled.
> In such environments like CloudFlare Workers, the request object in the context always has the initial request object, so it was impossible to access the actual Request object from the execution context. Now Yoga ensures that the request in the context is the same with the actual Request.

This should help improve issues with local development we are seeing across the board.

Tangentially...this is a very interesting read on how CF handles sharing context in between rqeuests and the diffrences of local-dev v/s prod
- https://github.com/cloudflare/next-on-pages/discussions/596#discussioncomment-8687242
- https://github.com/cloudflare/next-on-pages/discussions/596#discussioncomment-8606903