### PR TITLE
Adding payment links per community and event

### DIFF
--- a/src/datasources/mercadopago/index.ts
+++ b/src/datasources/mercadopago/index.ts
@@ -134,7 +134,7 @@ export const createMercadoPagoPayment = async ({
     back_urls: {
       success: `${paymentSuccessRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=approved`,
       failure: `${paymentCancelRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=rejected`,
-      pending: `${paymentSuccessRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=pending`,
+      pending: `${paymentCancelRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=pending`,
     },
     binary_mode: true,
     auto_return: "all",

--- a/src/datasources/mercadopago/index.ts
+++ b/src/datasources/mercadopago/index.ts
@@ -108,7 +108,8 @@ export const createMercadoPagoPayment = async ({
   user,
   purchaseOrderId,
   getMercadoPagoClient,
-  PURCHASE_CALLBACK_URL,
+  paymentSuccessRedirectURL,
+  paymentCancelRedirectURL,
   eventId,
 }: {
   items: Array<Items>;
@@ -118,7 +119,8 @@ export const createMercadoPagoPayment = async ({
   };
   purchaseOrderId: string;
   getMercadoPagoClient: MercadoPagoFetch;
-  PURCHASE_CALLBACK_URL: string;
+  paymentSuccessRedirectURL: string;
+  paymentCancelRedirectURL: string;
   eventId: string;
 }) => {
   const expirationDate = someMinutesIntoTheFuture(31);
@@ -130,9 +132,9 @@ export const createMercadoPagoPayment = async ({
     },
     items: items,
     back_urls: {
-      success: `${PURCHASE_CALLBACK_URL}?purchaseOrderId=${purchaseOrderId}&status=approved`,
-      failure: `${PURCHASE_CALLBACK_URL}?purchaseOrderId=${purchaseOrderId}&status=rejected`,
-      pending: `${PURCHASE_CALLBACK_URL}?purchaseOrderId=${purchaseOrderId}&status=pending`,
+      success: `${paymentSuccessRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=approved`,
+      failure: `${paymentCancelRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=rejected`,
+      pending: `${paymentSuccessRedirectURL}?purchaseOrderId=${purchaseOrderId}&status=pending`,
     },
     binary_mode: true,
     auto_return: "all",

--- a/src/datasources/stripe/index.ts
+++ b/src/datasources/stripe/index.ts
@@ -118,6 +118,7 @@ export const createStripePayment = async ({
     // https://stripe.com/docs/payments/checkout/custom-success-page
     success_url: `${paymentSuccessRedirectURL}?session_id={CHECKOUT_SESSION_ID}&purchaseOrderId=${purchaseOrderId}&status=approved`,
     cancel_url: `${paymentCancelRedirectURL}?session_id={CHECKOUT_SESSION_ID}&purchaseOrderId=${purchaseOrderId}&status=rejected`,
+    return_url: `${paymentSuccessRedirectURL}?session_id={CHECKOUT_SESSION_ID}&purchaseOrderId=${purchaseOrderId}&status=return`,
     // The URL the customer will be directed to if they decide to cancel
     // payment and return to your website.
     // cancel_url: `https://jsconf.cl/tickets`,

--- a/src/datasources/stripe/index.ts
+++ b/src/datasources/stripe/index.ts
@@ -96,7 +96,8 @@ export const createStripePayment = async ({
   items,
   purchaseOrderId,
   getStripeClient,
-  PURCHASE_CALLBACK_URL,
+  paymentSuccessRedirectURL,
+  paymentCancelRedirectURL,
 }: {
   items: Array<{
     price: string;
@@ -104,7 +105,8 @@ export const createStripePayment = async ({
   }>;
   purchaseOrderId: string;
   getStripeClient: () => Stripe;
-  PURCHASE_CALLBACK_URL: string;
+  paymentSuccessRedirectURL: string;
+  paymentCancelRedirectURL: string;
 }) => {
   const stripeClient = getStripeClient();
   const exirationDate = someMinutesIntoTheFuture(31);
@@ -114,7 +116,8 @@ export const createStripePayment = async ({
     // complete. If you’d like to use information from the successful Checkout
     // Session on your page, read the guide on customizing your success page.
     // https://stripe.com/docs/payments/checkout/custom-success-page
-    success_url: `${PURCHASE_CALLBACK_URL}?session_id={CHECKOUT_SESSION_ID}&purchaseOrderId=${purchaseOrderId}`,
+    success_url: `${paymentSuccessRedirectURL}?session_id={CHECKOUT_SESSION_ID}&purchaseOrderId=${purchaseOrderId}&status=approved`,
+    cancel_url: `${paymentCancelRedirectURL}?session_id={CHECKOUT_SESSION_ID}&purchaseOrderId=${purchaseOrderId}&status=rejected`,
     // The URL the customer will be directed to if they decide to cancel
     // payment and return to your website.
     // cancel_url: `https://jsconf.cl/tickets`,

--- a/src/schema/purchaseOrder/actions.tsx
+++ b/src/schema/purchaseOrder/actions.tsx
@@ -58,7 +58,8 @@ const createMercadoPagoPaymentIntent = async ({
   userTickets,
   purchaseOrderId,
   USER,
-  PURCHASE_CALLBACK_URL,
+  paymentSuccessRedirectURL,
+  paymentCancelRedirectURL,
   GET_MERCADOPAGO_CLIENT,
   logger,
 }: {
@@ -70,7 +71,8 @@ const createMercadoPagoPaymentIntent = async ({
   >;
   purchaseOrderId: string;
   GET_MERCADOPAGO_CLIENT: Context["GET_MERCADOPAGO_CLIENT"];
-  PURCHASE_CALLBACK_URL: string;
+  paymentSuccessRedirectURL: string;
+  paymentCancelRedirectURL: string;
   USER: {
     email: string;
     id: string;
@@ -132,7 +134,8 @@ const createMercadoPagoPaymentIntent = async ({
       email: USER.email,
       id: USER.id,
     },
-    PURCHASE_CALLBACK_URL,
+    paymentSuccessRedirectURL,
+    paymentCancelRedirectURL,
   });
 };
 
@@ -140,7 +143,8 @@ const createStripePaymentIntent = async ({
   purchaseOrderId,
   GET_STRIPE_CLIENT,
   userTickets,
-  PURCHASE_CALLBACK_URL,
+  paymentSuccessRedirectURL,
+  paymentCancelRedirectURL,
   logger,
 }: {
   userTickets: Array<
@@ -150,7 +154,8 @@ const createStripePaymentIntent = async ({
   >;
   purchaseOrderId: string;
   GET_STRIPE_CLIENT: Context["GET_STRIPE_CLIENT"];
-  PURCHASE_CALLBACK_URL: string;
+  paymentSuccessRedirectURL: string;
+  paymentCancelRedirectURL: string;
   logger: Logger<never>;
 }) => {
   const ticketsGroupedByTemplateId: Record<
@@ -198,7 +203,8 @@ const createStripePaymentIntent = async ({
     items,
     purchaseOrderId,
     getStripeClient: GET_STRIPE_CLIENT,
-    PURCHASE_CALLBACK_URL,
+    paymentSuccessRedirectURL,
+    paymentCancelRedirectURL,
   });
 
   return paymentLink;
@@ -211,7 +217,8 @@ export const createPaymentIntent = async ({
   GET_MERCADOPAGO_CLIENT,
   RESEND,
   GET_STRIPE_CLIENT,
-  PURCHASE_CALLBACK_URL,
+  paymentSuccessRedirectURL,
+  paymentCancelRedirectURL,
   logger,
 }: {
   DB: Context["DB"];
@@ -220,7 +227,8 @@ export const createPaymentIntent = async ({
   GET_STRIPE_CLIENT: Context["GET_STRIPE_CLIENT"];
   GET_MERCADOPAGO_CLIENT: Context["GET_MERCADOPAGO_CLIENT"];
   RESEND: Context["RESEND"];
-  PURCHASE_CALLBACK_URL: string;
+  paymentSuccessRedirectURL: string;
+  paymentCancelRedirectURL: string;
   currencyId: string;
   logger: Logger<never>;
 }) => {
@@ -442,7 +450,8 @@ export const createPaymentIntent = async ({
       userTickets,
       purchaseOrderId,
       GET_STRIPE_CLIENT,
-      PURCHASE_CALLBACK_URL,
+      paymentSuccessRedirectURL,
+      paymentCancelRedirectURL,
       logger,
     });
 
@@ -465,7 +474,8 @@ export const createPaymentIntent = async ({
         userTickets,
         purchaseOrderId,
         USER,
-        PURCHASE_CALLBACK_URL,
+        paymentSuccessRedirectURL,
+        paymentCancelRedirectURL,
         GET_MERCADOPAGO_CLIENT,
         logger,
       },

--- a/src/schema/purchaseOrder/helpers.ts
+++ b/src/schema/purchaseOrder/helpers.ts
@@ -1,0 +1,73 @@
+import { ORM_TYPE } from "~/datasources/db";
+
+export const getPurchaseRedirectURLsFromPurchaseOrder = async ({
+  DB,
+  default_redirect_url,
+  purchaseOrderId,
+}: {
+  DB: ORM_TYPE;
+  default_redirect_url: string;
+  purchaseOrderId: string;
+}) => {
+  const po = await DB.query.purchaseOrdersSchema.findFirst({
+    where: (pos, { eq }) => eq(pos.id, purchaseOrderId),
+    with: {
+      tickets: {
+        with: {
+          event: {
+            with: {
+              eventsToCommunities: {
+                with: {
+                  community: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!po) {
+    throw new Error("Purchase order not found");
+  }
+
+  const { tickets } = po;
+
+  if (!tickets.length) {
+    throw new Error("No tickets found for purchase order");
+  }
+
+  const { event } = tickets[0];
+
+  if (!event) {
+    throw new Error("Event not found for ticket");
+  }
+
+  const { eventsToCommunities } = event;
+
+  if (!eventsToCommunities) {
+    throw new Error("Event to community not found");
+  }
+
+  const { community } = eventsToCommunities[0];
+
+  if (!community) {
+    throw new Error("Community not found");
+  }
+
+  const paymentSuccessRedirectURL =
+    eventsToCommunities[0]?.paymentSuccessRedirectURL ??
+    community.paymentSuccessRedirectURL ??
+    default_redirect_url;
+
+  const paymentCancelRedirectURL =
+    eventsToCommunities[0]?.paymentCancelRedirectURL ??
+    community.paymentCancelRedirectURL ??
+    default_redirect_url;
+
+  return {
+    paymentSuccessRedirectURL,
+    paymentCancelRedirectURL,
+  };
+};

--- a/src/schema/purchaseOrder/mutations.tsx
+++ b/src/schema/purchaseOrder/mutations.tsx
@@ -1,6 +1,7 @@
 import { authHelpers } from "~/authz/helpers";
 import { builder } from "~/builder";
 import { selectPurchaseOrdersSchema } from "~/datasources/db/purchaseOrders";
+import { getPurchaseRedirectURLsFromPurchaseOrder } from "~/schema/purchaseOrder/helpers";
 
 import { createPaymentIntent, syncPurchaseOrderPaymentStatus } from "./actions";
 import { PurchaseOrderRef } from "./types";
@@ -50,13 +51,20 @@ builder.mutationField("payForPurchaseOrder", (t) =>
 
       const { purchaseOrderId, currencyID } = input;
 
+      const { paymentCancelRedirectURL, paymentSuccessRedirectURL } =
+        await getPurchaseRedirectURLsFromPurchaseOrder({
+          DB,
+          default_redirect_url: PURCHASE_CALLBACK_URL,
+          purchaseOrderId,
+        });
       const { purchaseOrder, ticketsIds } = await createPaymentIntent({
         DB,
         USER,
         RESEND,
         purchaseOrderId,
         GET_STRIPE_CLIENT,
-        PURCHASE_CALLBACK_URL,
+        paymentCancelRedirectURL,
+        paymentSuccessRedirectURL,
         GET_MERCADOPAGO_CLIENT,
         currencyId: currencyID,
         logger,

--- a/src/schema/userTickets/mutations.ts
+++ b/src/schema/userTickets/mutations.ts
@@ -463,6 +463,7 @@ builder.mutationFields((t) => ({
               selectPurchaseOrdersSchema.parse(foundPurchaseOrder);
 
             if (generatePaymentLink) {
+              logger.info("Extracting redirect URLs for purchase order");
               const { paymentSuccessRedirectURL, paymentCancelRedirectURL } =
                 await getPurchaseRedirectURLsFromPurchaseOrder({
                   DB: trx,
@@ -470,6 +471,7 @@ builder.mutationFields((t) => ({
                   default_redirect_url: PURCHASE_CALLBACK_URL,
                 });
 
+              logger.info("Generating payment link for purchase order");
               const { purchaseOrder, ticketsIds } = await createPaymentIntent({
                 DB,
                 USER,
@@ -494,7 +496,7 @@ builder.mutationFields((t) => ({
 
             return { selectedPurchaseOrder, claimedTickets };
           } catch (e) {
-            logger.error("🚨Error", e);
+            logger.error((e as Error).message);
             transactionError =
               e instanceof Error
                 ? new GraphQLError(e.message, {


### PR DESCRIPTION
Couple of PR's ago we created a way for events and communities to set their own success/cancel payment redirection link.

This PR actually implements the granular links by attaching them into payment providers purchase intents.
