### PR TITLE
Corregir relaciones de purchaseOrdersSchema: eliminar relación "tickets"

### DIFF
--- a/src/datasources/db/purchaseOrders.ts
+++ b/src/datasources/db/purchaseOrders.ts
@@ -11,7 +11,6 @@ import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
 import {
   allowedCurrencySchema,
-  ticketsSchema,
   userTicketsSchema,
   usersSchema,
 } from "./schema";
@@ -59,7 +58,6 @@ export const purchaseOrdersSchema = pgTable("purchase_orders", {
 export const purchaseOrdersRelations = relations(
   purchaseOrdersSchema,
   ({ one, many }) => ({
-    tickets: many(ticketsSchema),
     userTickets: many(userTicketsSchema),
     user: one(usersSchema, {
       fields: [purchaseOrdersSchema.userId],


### PR DESCRIPTION
Este PR corrige un problema en las relaciones de las órdenes de compra.

Se ha eliminado la relación "tickets" del esquema de relaciones de las órdenes de compra debido a que no hay suficiente información para inferir correctamente esta relación.

Esto permite usar drizzle studio sin problemas de forma local para navegar la base de datos.