### PR TITLE
Eliminar filtro de estado "complete" en query "myPurchaseOrders"

### DIFF
--- a/src/schema/purchaseOrder/queries.ts
+++ b/src/schema/purchaseOrder/queries.ts
@@ -36,7 +36,6 @@ builder.queryField("myPurchaseOrders", (t) =>
         await purchaseOrderFetcher.searchPaginatedPurchaseOrders({
           DB,
           search: {
-            status: ["complete"],
             userIds: [USER.id],
             paymentPlatform: input.search?.paymentPlatform
               ? ([input.search?.paymentPlatform] as ["stripe" | "mercadopago"])


### PR DESCRIPTION
Este PR modifica la consulta de órdenes de compra del usuario para incluir todas las órdenes, independientemente de su estado.

Cambios realizados:
- Se ha eliminado el filtro de estado "complete" en la consulta de órdenes de compra del usuario.

Esta modificación permite a los usuarios ver todas sus órdenes de compra, no solo las completadas. Esto mejorará la experiencia del usuario al proporcionar una visión más completa de su historial de compras, incluyendo órdenes en proceso o pendientes.