### PR TITLE
Correción data loaders: Orden de IDs para asociar correctamente los objetos en GraphQL

### DIFF
--- a/src/schema/events/types.ts
+++ b/src/schema/events/types.ts
@@ -87,12 +87,19 @@ const EventsTicketTemplateSearchInput = builder.inputType(
 export const EventLoadable = builder.loadableObject(EventRef, {
   description:
     "Representation of an Event (Events and Users, is what tickets are linked to)",
-  load: (ids: string[], context) =>
-    eventsFetcher.searchEvents({
+  load: async (ids: string[], context) => {
+    const result = await eventsFetcher.searchEvents({
       DB: context.DB,
       search: { eventIds: ids },
       sort: null,
-    }),
+    });
+
+    const resultByIdMap = new Map(result.map((item) => [item.id, item]));
+
+    return ids.map(
+      (id) => resultByIdMap.get(id) || new Error(`Event ${id} not found`),
+    );
+  },
   fields: (t) => ({
     id: t.exposeID("id", { nullable: false }),
     name: t.exposeString("name", { nullable: false }),

--- a/src/schema/schedules/types.ts
+++ b/src/schema/schedules/types.ts
@@ -19,11 +19,18 @@ export const ScheduleRef = builder.objectRef<ScheduleraphqlSchema>("Schedule");
 
 export const ScheduleLoadable = builder.loadableObject(ScheduleRef, {
   description: "Representation of a Schedule",
-  load: (ids: string[], context) =>
-    schedulesFetcher.searchSchedules({
+  load: async (ids: string[], context) => {
+    const result = await schedulesFetcher.searchSchedules({
       DB: context.DB,
       search: { scheduleIds: ids },
-    }),
+    });
+
+    const resultByIdMap = new Map(result.map((item) => [item.id, item]));
+
+    return ids.map(
+      (id) => resultByIdMap.get(id) || new Error(`Schedule ${id} not found`),
+    );
+  },
   fields: (t) => ({
     id: t.exposeID("id", { nullable: false }),
     title: t.exposeString("title", { nullable: false }),

--- a/src/schema/sessions/types.ts
+++ b/src/schema/sessions/types.ts
@@ -15,11 +15,18 @@ export const SessionRef = builder.objectRef<SessionGraphqlSchema>("Session");
 
 export const SessionLoadable = builder.loadableObject(SessionRef, {
   description: "Representation of a Session",
-  load: (ids: string[], context) =>
-    sessionsFetcher.searchSessions({
+  load: async (ids: string[], context) => {
+    const result = await sessionsFetcher.searchSessions({
       DB: context.DB,
       search: { sessionIds: ids },
-    }),
+    });
+
+    const resultByIdMap = new Map(result.map((item) => [item.id, item]));
+
+    return ids.map(
+      (id) => resultByIdMap.get(id) || new Error(`Session ${id} not found`),
+    );
+  },
   fields: (t) => ({
     id: t.exposeID("id", { nullable: false }),
     title: t.exposeString("title", { nullable: false }),

--- a/src/schema/speakers/types.ts
+++ b/src/schema/speakers/types.ts
@@ -13,12 +13,19 @@ export const SpeakerRef = builder.objectRef<SpeakerGraphqlSchema>("Speaker");
 
 export const SpeakerLoadable = builder.loadableObject(SpeakerRef, {
   description: "Representation of a Speaker",
-  load: (ids: string[], context) =>
-    speakersFetcher.searchSpeakers({
+  load: async (ids: string[], context) => {
+    const result = await speakersFetcher.searchSpeakers({
       DB: context.DB,
       search: { speakerIds: ids },
       sort: null,
-    }),
+    });
+
+    const resultByIdMap = new Map(result.map((item) => [item.id, item]));
+
+    return ids.map(
+      (id) => resultByIdMap.get(id) || new Error(`Speaker ${id} not found`),
+    );
+  },
   fields: (t) => ({
     id: t.exposeID("id", { nullable: false }),
     name: t.exposeString("name", { nullable: false }),

--- a/src/schema/ticket/types.ts
+++ b/src/schema/ticket/types.ts
@@ -34,10 +34,17 @@ builder.objectType(PriceRef, {
 
 export const TicketLoadable = builder.loadableObject(TicketRef, {
   description: "Representation of a ticket",
-  load: (ids: string[], context) =>
-    context.DB.query.ticketsSchema.findMany({
+  load: async (ids: string[], context) => {
+    const result = await context.DB.query.ticketsSchema.findMany({
       where: (t, { inArray }) => inArray(t.id, ids),
-    }),
+    });
+
+    const ticketMap = new Map(result.map((ticket) => [ticket.id, ticket]));
+
+    return ids.map(
+      (id) => ticketMap.get(id) || new Error(`Ticket ${id} not found`),
+    );
+  },
   fields: (t) => ({
     id: t.exposeID("id"),
     name: t.exposeString("name"),

--- a/src/schema/user/types.ts
+++ b/src/schema/user/types.ts
@@ -32,14 +32,20 @@ const RSVPFilterInput = builder.inputType("RSVPFilterInput", {
 
 export const UserLoadable = builder.loadableObject(UserRef, {
   description: "Representation of a user",
-  load: async (ids: string[], ctx) => {
-    const users = await usersFetcher.searchUsers({
-      DB: ctx.DB,
+  load: async (ids: string[], { DB }) => {
+    const result = await usersFetcher.searchUsers({
+      DB,
       search: { userIds: ids },
       sort: null,
     });
 
-    return users.map((user) => selectUsersSchema.parse(user));
+    const resultByIdMap = new Map(
+      result.map((item) => [item.id, selectUsersSchema.parse(item)]),
+    );
+
+    return ids.map(
+      (id) => resultByIdMap.get(id) || new Error(`Speaker ${id} not found`),
+    );
   },
   fields: (t) => ({
     id: t.exposeID("id", { nullable: false }),


### PR DESCRIPTION
Este Pull Request corrige un bug relacionado con el orden de los objetos devueltos, lo que estaba causando asociaciones incorrectas de datos.

Los cambios principales incluyen:
- Rediseño de data loaders: Se han modificado los data loaders en los esquemas de PurchaseOrder, Schedule, Session, Speaker, Ticket y User para garantizar que los resultados se devuelvan en el mismo orden que los IDs solicitados.
- Preservación del orden de IDs: Se ha implementado un sistema basado en Map dentro de los data loaders para indexar los resultados por ID, permitiendo una recuperación ordenada y rápida.
- Manejo de elementos no encontrados: Los data loaders ahora manejan casos donde ciertos IDs solicitados no existen, devolviendo errores específicos para cada tipo de objeto (lo cual permite mantener el orden de los IDs y devolver null por ejemplo)