### PR TITLE
Mejora en la validación de datos de usuario para la aprobación de tickets

### DIFF
--- a/src/tests/fixtures/index.ts
+++ b/src/tests/fixtures/index.ts
@@ -287,9 +287,8 @@ export const insertUserData = async (
 ) => {
   const possibleInput = {
     id: partialInput?.id ?? faker.string.uuid(),
-    city: partialInput?.city ?? faker.address.city(),
-    countryOfResidence:
-      partialInput?.countryOfResidence ?? faker.address.country(),
+    city: partialInput?.city || "",
+    countryOfResidence: partialInput?.countryOfResidence || "",
     worksInOrganization: partialInput?.worksInOrganization ?? false,
     emergencyPhoneNumber: partialInput?.emergencyPhoneNumber,
     foodAllergies: partialInput?.foodAllergies,


### PR DESCRIPTION
Este PR introduce mejoras en el proceso de validación de datos de usuario para la aprobación de tickets.

Los cambios principales incluyen:
1. Refactorización de la lógica de validación para diferenciar entre tickets de equipo (hackathon) y otros.
2. Eliminación de la lista hardcodeada de IDs de tickets de hackathon en producción, reemplazándola por una verificación basada en tags.
3. Actualización de las pruebas para cubrir escenarios de tickets de equipo y otros.