### PR TITLE
fix: getMercadoPagoPayment, guardado de currencyId y totalPrice en purchaseOrder

### DIFF
--- a/src/datasources/mercadopago/index.ts
+++ b/src/datasources/mercadopago/index.ts
@@ -194,6 +194,5 @@ export const getMercadoPagoPayment = async ({
   return {
     paymentStatus: getPaymentStatusFromMercadoPago(lastPaymentHistory?.status),
     status: getPurchasOrderStatusFromMercadoPago(lastPaymentHistory?.status),
-    totalPaidAmount: lastPaymentHistory?.transaction_amount,
   };
 };

--- a/src/datasources/mercadopago/index.ts
+++ b/src/datasources/mercadopago/index.ts
@@ -176,18 +176,24 @@ export const getMercadoPagoPreference = async ({
 };
 
 export const getMercadoPagoPayment = async ({
-  paymentId,
+  purchaseOrderId,
   getMercadoPagoClient,
 }: {
-  paymentId: string;
+  purchaseOrderId: string;
   getMercadoPagoClient: MercadoPagoFetch;
 }) => {
-  const payment = await getMercadoPagoClient<PaymentResponse>({
-    url: `/v1/payments/${paymentId}`,
+  const result = await getMercadoPagoClient<{ results: PaymentResponse[] }>({
+    url: `/v1/payments/search?external_reference=${purchaseOrderId}`,
   });
 
+  const lastPaymentHistory =
+    result.results.length > 0
+      ? result.results[result.results.length - 1]
+      : null;
+
   return {
-    paymentStatus: getPaymentStatusFromMercadoPago(payment.status),
-    status: getPurchasOrderStatusFromMercadoPago(payment.status),
+    paymentStatus: getPaymentStatusFromMercadoPago(lastPaymentHistory?.status),
+    status: getPurchasOrderStatusFromMercadoPago(lastPaymentHistory?.status),
+    totalPaidAmount: lastPaymentHistory?.transaction_amount,
   };
 };


### PR DESCRIPTION
Este PR introduce mejoras y correcciones en la gestión de pagos con MercadoPago y en el manejo de órdenes de compra:

1. Modificación de getMercadoPagoPayment:
   - Ahora utiliza purchaseOrderId en lugar de paymentId.
   - Busca pagos por external_reference en lugar de un pago específico.
   - Devuelve información del último pago encontrado.

2. Actualización en createPaymentIntent:
   - Ahora guarda currencyId en la orden de compra.

3. Mejoras en syncPurchaseOrderPaymentStatus:
   - Para MercadoPago, ahora usa purchaseOrderId para obtener el estado del pago.
   - Actualiza totalPrice en la orden de compra con el monto pagado de MercadoPago.

4. Actualizaciones en la tabla de órdenes de compra:
   - Se añade totalPrice a las columnas actualizadas.
   
5. Corrige un bug al crear pagos en CLP que causaba que se crearan los ordenes con precios en USD u otra moneda