### PR TITLE
Optimizar proceso de creación/actualización de usuarios y resolver race condition

### DIFF
--- a/src/authn/index.ts
+++ b/src/authn/index.ts
@@ -5,7 +5,7 @@ import { ORM_TYPE } from "~/datasources/db";
 import { insertUsersSchema, USER } from "~/datasources/db/schema";
 import {
   findUserByID,
-  updateUserProfileInfo,
+  upsertUserProfileInfo,
 } from "~/datasources/queries/users";
 import { getUsername } from "~/datasources/queries/utils/createUsername";
 import { unauthorizedError } from "~/errors";
@@ -141,7 +141,7 @@ export const upsertUserFromRequest = async ({
 
   logger.info(`Updating profile Info for user ID: ${sub}`);
 
-  return updateUserProfileInfo(DB, profileInfo.data, logger);
+  return upsertUserProfileInfo(DB, profileInfo.data, logger);
 };
 
 export const logPossibleUserIdFromJWT = (request: Request, logger: Logger) => {


### PR DESCRIPTION
Este PR aborda un problema crítico de race condition en la creación de usuarios y mejora significativamente el performance general de nuestro sistema de gestión de usuarios.

### Problema actual:

Actualmente, cuando se realizan múltiples llamadas concurrentes a endpoints autenticados (por ejemplo, usando `await Promise.all([...])`) para un usuario que se está autenticando por primera vez, puede ocurrir una race condition. Esto resulta en un error de clave duplicada:

```
(error) 🚨 APPLICATION ERROR of: duplicate key value violates unique constraint "users_email_unique" Internal Server Error
```

Este error se produce porque múltiples procesos intentan crear el mismo usuario simultáneamente, violando la restricción de unicidad en el email.

### Cambios propuestos:

1. Reemplazar `updateUserProfileInfo` con `upsertUserProfileInfo`:
   - Esta nueva función maneja tanto la creación como las actualizaciones de usuarios en una sola operación atómica.
   - Elimina la necesidad de verificar la existencia del usuario antes de decidir si crear o actualizar.

2. Implementar una operación upsert utilizando `onConflictDoUpdate`:
   - Esto previene las race conditions durante intentos concurrentes de creación de usuarios.
   - Si un usuario ya existe, la operación se convierte automáticamente en una actualización, evitando así el error de clave duplicada.

### Beneficios:

- **Eliminación de errores:** Resuelve la race condition que causaba errores de usuarios duplicados.
- **Mejora de performance:** Reduce el número de operaciones de base de datos necesarias. Además esta es una operación critica dado que esta operación se realiza en cada request.