### PR TITLE
[DRAFT] Refactorización de estados de UserTicket a enums y mejora de documentación

### DIFF
--- a/src/datasources/db/userTickets.ts
+++ b/src/datasources/db/userTickets.ts
@@ -7,12 +7,48 @@ import { purchaseOrdersSchema, ticketsSchema, usersSchema } from "./schema";
 import { createdAndUpdatedAtFields } from "./shared";
 
 export enum UserTicketApprovalStatus {
+  /**
+   * TODO: Document the use case for this status
+   * This status is used when a ticket is approved by:
+   * - Paying the ticket from a purchase order (not created by a waitlist)
+   * - Calling approvalUserTicket (as a super admin or community admin)
+   * - Accepting a gifted ticket
+   */
   Approved = "approved",
+  /**
+   * TODO: Document the waitlist use case because it is not clear how to get out of this status
+   * The DB default value represents one of the following:
+   * - The ticket has been purchased but not yet paid
+   * - The ticket is on a waitlist
+   */
   Pending = "pending",
+  /**
+   * TODO: Document this status better because the use case is not clear
+   * The mutation acceptGiftedTicket sets the status to Approved not GiftAccepted
+   */
   GiftAccepted = "gift_accepted",
+  /**
+   * TODO: Document this status better and the relation with GiftAccepted if there is any
+   * The ticket was gifted by an admin trough retool
+   * the status changes to Approved when the users fills some data
+   * it was mainly used for the AI Hackathon 2024
+   */
   Gifted = "gifted",
+  /**
+   * TODO: Document use case for this status
+   */
   NotRequired = "not_required",
+  /**
+   * TODO: Document use case for this status
+   */
   Rejected = "rejected",
+  /**
+   * TODO: Document this status better because the use case is not clear
+   * This status is used when a ticket is cancelled by:
+   * - The owner of the ticket
+   * - A super admin
+   * - A event community admin
+   */
   Cancelled = "cancelled",
 }
 
@@ -32,7 +68,13 @@ export enum UserTicketRedemptionStatus {
 }
 
 export const userTicketsRedemptionStatusEnum = [
+  /**
+   * The user has redeemed the ticket by assisting to the event
+   */
   UserTicketRedemptionStatus.Redeemed,
+  /**
+   * The user has not redeemed the ticket yet
+   */
   UserTicketRedemptionStatus.Pending,
 ] as const;
 

--- a/src/datasources/db/userTickets.ts
+++ b/src/datasources/db/userTickets.ts
@@ -1,21 +1,40 @@
 import { relations } from "drizzle-orm";
 import { index, pgTable, text, uuid } from "drizzle-orm/pg-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
 
 import { purchaseOrdersSchema, ticketsSchema, usersSchema } from "./schema";
 import { createdAndUpdatedAtFields } from "./shared";
 
+export enum UserTicketApprovalStatus {
+  Approved = "approved",
+  Pending = "pending",
+  GiftAccepted = "gift_accepted",
+  Gifted = "gifted",
+  NotRequired = "not_required",
+  Rejected = "rejected",
+  Cancelled = "cancelled",
+}
+
 export const userTicketsApprovalStatusEnum = [
-  "approved",
-  "pending",
-  "gift_accepted",
-  "gifted",
-  "not_required",
-  "rejected",
-  "cancelled",
+  UserTicketApprovalStatus.Approved,
+  UserTicketApprovalStatus.Pending,
+  UserTicketApprovalStatus.GiftAccepted,
+  UserTicketApprovalStatus.Gifted,
+  UserTicketApprovalStatus.NotRequired,
+  UserTicketApprovalStatus.Rejected,
+  UserTicketApprovalStatus.Cancelled,
 ] as const;
 
-export const userTicketsRedemptionStatusEnum = ["redeemed", "pending"] as const;
+export enum UserTicketRedemptionStatus {
+  Redeemed = "redeemed",
+  Pending = "pending",
+}
+
+export const userTicketsRedemptionStatusEnum = [
+  UserTicketRedemptionStatus.Redeemed,
+  UserTicketRedemptionStatus.Pending,
+] as const;
 
 // USER-TICKETS-TABLE
 export const userTicketsSchema = pgTable(
@@ -33,12 +52,15 @@ export const userTicketsSchema = pgTable(
     approvalStatus: text("approval_status", {
       enum: userTicketsApprovalStatusEnum,
     })
-      .default("pending")
+      .default(UserTicketApprovalStatus.Pending)
       .notNull(),
     redemptionStatus: text("redemption_status", {
-      enum: userTicketsRedemptionStatusEnum,
+      enum: [
+        UserTicketRedemptionStatus.Redeemed,
+        UserTicketRedemptionStatus.Pending,
+      ],
     })
-      .default("pending")
+      .default(UserTicketRedemptionStatus.Pending)
       .notNull(),
     ...createdAndUpdatedAtFields,
   },
@@ -69,3 +91,7 @@ export const insertUserTicketsSchema = createInsertSchema(userTicketsSchema);
 export const approveUserTicketsSchema = selectUserTicketsSchema.pick({
   approvalStatus: true,
 });
+
+export type InsertUserTicketSchema = z.infer<typeof insertUserTicketsSchema>;
+
+export type SelectUserTicketSchema = z.infer<typeof selectUserTicketsSchema>;

--- a/src/generated/schema.gql
+++ b/src/generated/schema.gql
@@ -606,6 +606,19 @@ enum PronounsEnum {
 }
 
 """
+Representation of the public data for a user's event attendance, used usually for public profiles or 'shareable ticket' pages
+"""
+type PublicEventAttendance {
+  event: Event!
+  id: ID!
+  userInfo: PublicUserInfo!
+}
+
+input PublicEventAttendanceInfo {
+  id: String!
+}
+
+"""
 Representation of a payment log entry
 """
 type PublicFinanceEntryRef {
@@ -619,6 +632,16 @@ type PublicFinanceEntryRef {
 
 input PublicTicketInput {
   publicTicketId: String!
+}
+
+"""
+Representation of a user's publicly accessible data, to be used in public contexts like shareable ticket UIs
+"""
+type PublicUserInfo {
+  firstName: String
+  lastName: String
+  profilePicture: String
+  userName: String!
 }
 
 """
@@ -723,6 +746,13 @@ type Query {
   Get a list of tickets for the current user
   """
   myTickets(input: PaginatedInputMyTicketsSearchValues!): PaginatedUserTicket!
+
+  """
+  Get public event attendance info
+  """
+  publicEventAttendanceInfo(
+    input: PublicEventAttendanceInfo!
+  ): PublicEventAttendance
 
   """
   Get a list of user tickets

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -650,6 +650,18 @@ export enum PronounsEnum {
   TheyThem = "theyThem",
 }
 
+/** Representation of the public data for a user's event attendance, used usually for public profiles or 'shareable ticket' pages */
+export type PublicEventAttendance = {
+  __typename?: "PublicEventAttendance";
+  event: Event;
+  id: Scalars["ID"]["output"];
+  userInfo: PublicUserInfo;
+};
+
+export type PublicEventAttendanceInfo = {
+  id: Scalars["String"]["input"];
+};
+
 /** Representation of a payment log entry */
 export type PublicFinanceEntryRef = {
   __typename?: "PublicFinanceEntryRef";
@@ -663,6 +675,15 @@ export type PublicFinanceEntryRef = {
 
 export type PublicTicketInput = {
   publicTicketId: Scalars["String"]["input"];
+};
+
+/** Representation of a user's publicly accessible data, to be used in public contexts like shareable ticket UIs */
+export type PublicUserInfo = {
+  __typename?: "PublicUserInfo";
+  firstName?: Maybe<Scalars["String"]["output"]>;
+  lastName?: Maybe<Scalars["String"]["output"]>;
+  profilePicture?: Maybe<Scalars["String"]["output"]>;
+  userName: Scalars["String"]["output"];
 };
 
 /** Representation of the public information of a User ticket */
@@ -730,6 +751,8 @@ export type Query = {
   myPurchaseOrders: PaginatedPurchaseOrder;
   /** Get a list of tickets for the current user */
   myTickets: PaginatedUserTicket;
+  /** Get public event attendance info */
+  publicEventAttendanceInfo?: Maybe<PublicEventAttendance>;
   /** Get a list of user tickets */
   publicTicketInfo: PublicUserTicket;
   /** Get a list of salaries associated to the user */
@@ -800,6 +823,10 @@ export type QueryMyPurchaseOrdersArgs = {
 
 export type QueryMyTicketsArgs = {
   input: PaginatedInputMyTicketsSearchValues;
+};
+
+export type QueryPublicEventAttendanceInfoArgs = {
+  input: PublicEventAttendanceInfo;
 };
 
 export type QueryPublicTicketInfoArgs = {

--- a/src/schema/events/eventsFetcher.ts
+++ b/src/schema/events/eventsFetcher.ts
@@ -17,6 +17,7 @@ import {
   userTicketsSchema,
   ticketsSchema,
   eventsToCommunitiesSchema,
+  UserTicketApprovalStatus,
 } from "~/datasources/db/schema";
 import {
   PaginationOptionsType,
@@ -95,7 +96,10 @@ const getSearchEventsQuery = (
         .where(
           and(
             inArray(userTicketsSchema.ticketTemplateId, subquery),
-            eq(userTicketsSchema.approvalStatus, "approved"),
+            eq(
+              userTicketsSchema.approvalStatus,
+              UserTicketApprovalStatus.Approved,
+            ),
             eq(userTicketsSchema.userId, userId),
           ),
         ),

--- a/src/schema/events/tests/events.test.ts
+++ b/src/schema/events/tests/events.test.ts
@@ -6,6 +6,10 @@ import {
   UserTeamRoleEnum,
 } from "~/datasources/db/userTeams";
 import {
+  UserTicketApprovalStatus,
+  UserTicketRedemptionStatus,
+} from "~/datasources/db/userTickets";
+import {
   EventStatus,
   EventVisibility,
   ParticipationStatus,
@@ -155,34 +159,34 @@ describe("Event", () => {
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "approved",
+      approvalStatus: UserTicketApprovalStatus.Approved,
     });
 
     await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "cancelled",
+      approvalStatus: UserTicketApprovalStatus.Cancelled,
     });
 
     await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "pending",
+      approvalStatus: UserTicketApprovalStatus.Pending,
     });
     const ticket2 = await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "not_required",
+      approvalStatus: UserTicketApprovalStatus.NotRequired,
     });
 
     await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user2.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "approved",
+      approvalStatus: UserTicketApprovalStatus.Approved,
     });
     const response = await executeGraphqlOperationAsUser<
       EventQuery,
@@ -236,7 +240,7 @@ describe("Event", () => {
           createdAt: toISODate(ticket1.createdAt),
         },
       ],
-    } as EventQuery["event"]);
+    } as unknown as EventQuery["event"]);
   });
 
   it("Should get an event community", async () => {
@@ -540,7 +544,7 @@ describe("Events", () => {
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "approved",
+      approvalStatus: UserTicketApprovalStatus.Approved,
     });
 
     const purchaseOrder2 = await insertPurchaseOrder();
@@ -549,7 +553,7 @@ describe("Events", () => {
       ticketTemplateId: ticketTemplate2.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder2.id,
-      approvalStatus: "cancelled",
+      approvalStatus: UserTicketApprovalStatus.Cancelled,
     });
 
     await insertEvent({
@@ -778,7 +782,7 @@ describe("Event tickets filter", () => {
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: TicketApprovalStatus.Approved,
+      approvalStatus: UserTicketApprovalStatus.Approved,
     });
 
     await insertTicket({
@@ -833,7 +837,7 @@ describe("Event tickets filter", () => {
           createdAt: toISODate(ticket1.createdAt),
         },
       ],
-    } as EventQuery["event"]);
+    } as unknown as EventQuery["event"]);
   });
 
   it("Should filter event ticket by approval status", async () => {
@@ -864,14 +868,14 @@ describe("Event tickets filter", () => {
     const ticket1 = await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
-      approvalStatus: TicketApprovalStatus.Approved,
+      approvalStatus: UserTicketApprovalStatus.Approved,
       purchaseOrderId: purchaseOrder.id,
     });
 
     await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
-      approvalStatus: TicketApprovalStatus.Pending,
+      approvalStatus: UserTicketApprovalStatus.Pending,
       purchaseOrderId: purchaseOrder.id,
     });
     const response = await executeGraphqlOperationAsUser<
@@ -921,7 +925,7 @@ describe("Event tickets filter", () => {
           createdAt: toISODate(ticket1.createdAt),
         },
       ],
-    } as EventQuery["event"]);
+    } as unknown as EventQuery["event"]);
   });
 
   it("Should filter event ticket by payment status", async () => {
@@ -956,7 +960,7 @@ describe("Event tickets filter", () => {
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: TicketApprovalStatus.Approved,
+      approvalStatus: UserTicketApprovalStatus.Approved,
       createdAt: date1,
     });
 
@@ -965,7 +969,7 @@ describe("Event tickets filter", () => {
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: TicketApprovalStatus.Approved,
+      approvalStatus: UserTicketApprovalStatus.Approved,
       createdAt: date2,
     });
     const response = await executeGraphqlOperationAsUser<
@@ -1022,7 +1026,7 @@ describe("Event tickets filter", () => {
           createdAt: toISODate(ticket1.createdAt),
         },
       ],
-    } as EventQuery["event"]);
+    } as unknown as EventQuery["event"]);
   });
 
   it("Should filter event ticket by redemption status", async () => {
@@ -1053,17 +1057,17 @@ describe("Event tickets filter", () => {
     const ticket1 = await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
-      redemptionStatus: TicketRedemptionStatus.Redeemed,
+      redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: TicketApprovalStatus.Approved,
+      approvalStatus: UserTicketApprovalStatus.Approved,
     });
 
     await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
-      redemptionStatus: TicketRedemptionStatus.Pending,
+      redemptionStatus: UserTicketRedemptionStatus.Pending,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: TicketApprovalStatus.Approved,
+      approvalStatus: UserTicketApprovalStatus.Approved,
     });
     const response = await executeGraphqlOperationAsUser<
       EventQuery,
@@ -1112,6 +1116,6 @@ describe("Event tickets filter", () => {
           createdAt: toISODate(ticket1.createdAt),
         },
       ],
-    } as EventQuery["event"]);
+    } as unknown as EventQuery["event"]);
   });
 });

--- a/src/schema/events/types.ts
+++ b/src/schema/events/types.ts
@@ -4,6 +4,7 @@ import { authHelpers } from "~/authz/helpers";
 import { builder } from "~/builder";
 import {
   ScheduleStatus,
+  UserTicketApprovalStatus,
   selectCommunitySchema,
   selectGalleriesSchema,
   selectScheduleSchema,
@@ -366,7 +367,10 @@ export const EventLoadable = builder.loadableObject(EventRef, {
             eventIds: [root.id],
             userIds: [USER.id],
             paymentStatus: paymentStatus ? [paymentStatus] : undefined,
-            approvalStatus: ["approved", "not_required"],
+            approvalStatus: [
+              UserTicketApprovalStatus.Approved,
+              UserTicketApprovalStatus.NotRequired,
+            ],
             redemptionStatus: redemptionStatus ? [redemptionStatus] : undefined,
           },
         });

--- a/src/schema/invitations/mutations.ts
+++ b/src/schema/invitations/mutations.ts
@@ -4,6 +4,7 @@ import { builder } from "~/builder";
 import {
   insertUserTicketsSchema,
   selectUserTicketsSchema,
+  UserTicketApprovalStatus,
   userTicketsSchema,
 } from "~/datasources/db/schema";
 import { applicationError, ServiceErrors } from "~/errors";
@@ -140,7 +141,9 @@ builder.mutationField("giftTicketsToUsers", (t) =>
             userId,
             ticketTemplateId,
             purchaseOrderId: purchaseOrder.id,
-            approvalStatus: autoApproveTickets ? "approved" : "gifted",
+            approvalStatus: autoApproveTickets
+              ? UserTicketApprovalStatus.Approved
+              : UserTicketApprovalStatus.Gifted,
           });
 
           ticketsToInsert.push(parsedData);

--- a/src/schema/purchaseOrder/actions.tsx
+++ b/src/schema/purchaseOrder/actions.tsx
@@ -5,6 +5,7 @@ import { AsyncReturnType } from "type-fest";
 import { ORM_TYPE } from "~/datasources/db";
 import {
   USER,
+  UserTicketApprovalStatus,
   puchaseOrderPaymentStatusEnum,
   purchaseOrderStatusEnum,
   purchaseOrdersSchema,
@@ -640,7 +641,7 @@ export const syncPurchaseOrderPaymentStatus = async ({
     if (poPaymentStatus === "paid") {
       await DB.update(userTicketsSchema)
         .set({
-          approvalStatus: "approved",
+          approvalStatus: UserTicketApprovalStatus.Approved,
         })
         .where(eq(userTicketsSchema.purchaseOrderId, purchaseOrderId));
     }

--- a/src/schema/ticket/types.ts
+++ b/src/schema/ticket/types.ts
@@ -1,5 +1,8 @@
 import { builder } from "~/builder";
-import { selectAllowedCurrencySchema } from "~/datasources/db/schema";
+import {
+  selectAllowedCurrencySchema,
+  UserTicketApprovalStatus,
+} from "~/datasources/db/schema";
 import { EventLoadable } from "~/schema/events/types";
 import { AllowedCurrencyRef, PriceRef, TicketRef } from "~/schema/shared/refs";
 
@@ -89,11 +92,11 @@ export const TicketLoadable = builder.loadableObject(TicketRef, {
             and(
               eq(ut.ticketTemplateId, root.id),
               inArray(ut.approvalStatus, [
-                "approved",
-                "gift_accepted",
-                "not_required",
-                "pending",
-                "gifted",
+                UserTicketApprovalStatus.Approved,
+                UserTicketApprovalStatus.GiftAccepted,
+                UserTicketApprovalStatus.NotRequired,
+                UserTicketApprovalStatus.Pending,
+                UserTicketApprovalStatus.Gifted,
               ]),
             ),
         });

--- a/src/schema/user/types.ts
+++ b/src/schema/user/types.ts
@@ -7,6 +7,7 @@ import {
   selectTeamsSchema,
   selectUsersSchema,
   selectUserTicketsSchema,
+  UserTicketApprovalStatus,
 } from "~/datasources/db/schema";
 import {
   CommunityRef,
@@ -132,7 +133,12 @@ export const UserLoadable = builder.loadableObject(UserRef, {
             userIds: [root.id],
             approvalStatus: ctx.USER?.isSuperAdmin
               ? undefined
-              : ["approved", "gifted", "gift_accepted", "not_required"],
+              : [
+                  UserTicketApprovalStatus.Approved,
+                  UserTicketApprovalStatus.Gifted,
+                  UserTicketApprovalStatus.GiftAccepted,
+                  UserTicketApprovalStatus.NotRequired,
+                ],
           },
         });
 

--- a/src/schema/userTickets/helpers.ts
+++ b/src/schema/userTickets/helpers.ts
@@ -6,6 +6,7 @@ import { USER } from "~/datasources/db/users";
 import { UserParticipationStatusEnum } from "~/datasources/db/userTeams";
 import {
   approveUserTicketsSchema,
+  UserTicketApprovalStatus,
   userTicketsSchema,
 } from "~/datasources/db/userTickets";
 import { applicationError, ServiceErrors } from "~/errors";
@@ -167,7 +168,7 @@ export const validateUserDataAndApproveUserTickets = async ({
     search: {
       userIds: [userId],
       eventIds: [eventId],
-      approvalStatus: ["gifted"],
+      approvalStatus: [UserTicketApprovalStatus.Gifted],
     },
   });
 
@@ -277,7 +278,7 @@ const bulkApproveUserTickets = async ({
   const updated = await DB.update(userTicketsSchema)
     .set(
       approveUserTicketsSchema.parse({
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
       }),
     )
     .where(inArray(userTicketsSchema.id, userTicketIds))

--- a/src/schema/userTickets/mutations.ts
+++ b/src/schema/userTickets/mutations.ts
@@ -163,11 +163,11 @@ builder.mutationField("approvalUserTicket", (t) =>
           throw new GraphQLError("Unauthorized!");
         }
 
-        if (ticket.approvalStatus === "approved") {
+        if (ticket.approvalStatus === UserTicketApprovalStatus.Approved) {
           throw new GraphQLError("Ticket already approved");
         }
 
-        if (ticket.approvalStatus !== "pending") {
+        if (ticket.approvalStatus !== UserTicketApprovalStatus.Pending) {
           throw new GraphQLError("Ticket cannot be approved");
         }
 
@@ -443,7 +443,9 @@ builder.mutationField("claimUserTicket", (t) =>
                     purchaseOrderId: createdPurchaseOrder.id,
                     ticketTemplateId: ticketTemplate.id,
                     paymentStatus: requiresPayment ? "unpaid" : "not_required",
-                    approvalStatus: isApproved ? "approved" : "pending",
+                    approvalStatus: isApproved
+                      ? UserTicketApprovalStatus.Approved
+                      : UserTicketApprovalStatus.Pending,
                   });
 
                   if (result.success) {
@@ -603,7 +605,7 @@ builder.mutationField("acceptGiftedTicket", (t) =>
         throw new GraphQLError("Could not find ticket to accept");
       }
 
-      if (ticket.approvalStatus !== "gifted") {
+      if (ticket.approvalStatus !== UserTicketApprovalStatus.Gifted) {
         throw new GraphQLError("Ticket is not a gifted ticket");
       }
 

--- a/src/schema/userTickets/mutations.ts
+++ b/src/schema/userTickets/mutations.ts
@@ -6,6 +6,8 @@ import {
   insertUserTicketsSchema,
   selectPurchaseOrdersSchema,
   selectUserTicketsSchema,
+  UserTicketApprovalStatus,
+  UserTicketRedemptionStatus,
   userTicketsSchema,
 } from "~/datasources/db/schema";
 import { applicationError, ServiceErrors } from "~/errors";
@@ -110,7 +112,7 @@ builder.mutationField("cancelUserTicket", (t) =>
         ticket = (
           await ctx.DB.update(userTicketsSchema)
             .set({
-              approvalStatus: "cancelled",
+              approvalStatus: UserTicketApprovalStatus.Cancelled,
               deletedAt: new Date(),
             })
             .where(eq(userTicketsSchema.id, userTicketId))
@@ -176,7 +178,7 @@ builder.mutationField("approvalUserTicket", (t) =>
         const updatedTicket = (
           await DB.update(userTicketsSchema)
             .set({
-              approvalStatus: "approved",
+              approvalStatus: UserTicketApprovalStatus.Approved,
             })
             .where(eq(userTicketsSchema.id, userTicketId))
             .returning()
@@ -223,22 +225,22 @@ builder.mutationField("redeemUserTicket", (t) =>
           throw new GraphQLError("Unauthorized!");
         }
 
-        if (ticket.approvalStatus === "cancelled") {
+        if (ticket.approvalStatus === UserTicketApprovalStatus.Cancelled) {
           throw new GraphQLError("No es posible redimir un ticket cancelado");
         }
 
-        if (ticket.approvalStatus === "rejected") {
+        if (ticket.approvalStatus === UserTicketApprovalStatus.Rejected) {
           throw new GraphQLError("No es posible redimir un ticket rechazado");
         }
 
-        if (ticket.redemptionStatus === "redeemed") {
+        if (ticket.redemptionStatus === UserTicketRedemptionStatus.Redeemed) {
           return selectUserTicketsSchema.parse(ticket);
         }
 
         const updatedTicket = (
           await DB.update(userTicketsSchema)
             .set({
-              redemptionStatus: "redeemed",
+              redemptionStatus: UserTicketRedemptionStatus.Redeemed,
             })
             .where(eq(userTicketsSchema.id, userTicketId))
             .returning()
@@ -409,7 +411,10 @@ builder.mutationField("claimUserTicket", (t) =>
                   where: (uts, { eq, and, notInArray }) =>
                     and(
                       eq(uts.ticketTemplateId, ticketId),
-                      notInArray(uts.approvalStatus, ["rejected", "cancelled"]),
+                      notInArray(uts.approvalStatus, [
+                        UserTicketApprovalStatus.Rejected,
+                        UserTicketApprovalStatus.Cancelled,
+                      ]),
                     ),
                   columns: {
                     id: true,
@@ -470,7 +475,10 @@ builder.mutationField("claimUserTicket", (t) =>
                 where: (uts, { eq, and, inArray }) =>
                   and(
                     eq(uts.ticketTemplateId, ticketId),
-                    inArray(uts.approvalStatus, ["approved", "pending"]),
+                    inArray(uts.approvalStatus, [
+                      UserTicketApprovalStatus.Approved,
+                      UserTicketApprovalStatus.Pending,
+                    ]),
                   ),
               });
 
@@ -602,7 +610,7 @@ builder.mutationField("acceptGiftedTicket", (t) =>
       const updatedTicket = (
         await DB.update(userTicketsSchema)
           .set({
-            approvalStatus: "approved",
+            approvalStatus: UserTicketApprovalStatus.Approved,
           })
           .where(eq(userTicketsSchema.id, userTicketId))
           .returning()

--- a/src/schema/userTickets/queries.ts
+++ b/src/schema/userTickets/queries.ts
@@ -2,7 +2,7 @@ import { builder } from "~/builder";
 import {
   selectUserTicketsSchema,
   USER,
-  userTicketsApprovalStatusEnum,
+  UserTicketApprovalStatus,
 } from "~/datasources/db/schema";
 import { applicationError, ServiceErrors } from "~/errors";
 import {
@@ -42,10 +42,7 @@ const MyTicketsSearchValues = builder.inputType("MyTicketsSearchValues", {
 const PaginatedUserTicketsRef = createPaginationObjectType(UserTicketRef);
 
 const getQueryApprovalStatus = (
-  approvalStatus:
-    | (typeof userTicketsApprovalStatusEnum)[number][]
-    | null
-    | undefined,
+  approvalStatus: UserTicketApprovalStatus[] | null | undefined,
   user: USER,
 ) => {
   if (approvalStatus) {
@@ -61,9 +58,12 @@ const getQueryApprovalStatus = (
   }
 };
 
-const normalUserAllowedAppovalStatus = new Set<
-  (typeof userTicketsApprovalStatusEnum)[number]
->(["approved", "not_required", "gifted", "gift_accepted"]);
+const normalUserAllowedAppovalStatus = new Set<UserTicketApprovalStatus>([
+  UserTicketApprovalStatus.Approved,
+  UserTicketApprovalStatus.NotRequired,
+  UserTicketApprovalStatus.Gifted,
+  UserTicketApprovalStatus.GiftAccepted,
+]);
 
 builder.queryFields((t) => ({
   myTickets: t.field({
@@ -214,7 +214,10 @@ builder.queryField("publicTicketInfo", (t) =>
           DB,
           search: {
             publicIds: [publicTicketId],
-            approvalStatus: ["approved", "gift_accepted"],
+            approvalStatus: [
+              UserTicketApprovalStatus.Approved,
+              UserTicketApprovalStatus.GiftAccepted,
+            ],
           },
           pagination: {
             page: 0,

--- a/src/schema/userTickets/tests/acceptGiftedTickets/acceptGiftedTicket.test.ts
+++ b/src/schema/userTickets/tests/acceptGiftedTickets/acceptGiftedTicket.test.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { it, describe, assert } from "vitest";
 
-import { userTicketsApprovalStatusEnum } from "~/datasources/db/userTickets";
+import { UserTicketApprovalStatus } from "~/datasources/db/userTickets";
 import {
   executeGraphqlOperationAsUser,
   insertCommunity,
@@ -20,7 +20,7 @@ import {
 } from "./acceptGiftedTicket.generated";
 
 const prepareTickets = async (
-  status: (typeof userTicketsApprovalStatusEnum)[number] = "gifted",
+  status: UserTicketApprovalStatus = UserTicketApprovalStatus.Gifted,
 ) => {
   const community1 = await insertCommunity();
   const event1 = await insertEvent();
@@ -115,7 +115,9 @@ describe("Redeem user ticket", () => {
     });
 
     it("If tickets is not in a gifted state", async () => {
-      const { ticket, user } = await prepareTickets("gift_accepted");
+      const { ticket, user } = await prepareTickets(
+        UserTicketApprovalStatus.GiftAccepted,
+      );
       const response = await executeGraphqlOperationAsUser<
         AcceptGiftedTicketMutation,
         AcceptGiftedTicketMutationVariables

--- a/src/schema/userTickets/tests/approvalUserTicket/approvalUserTicket.test.ts
+++ b/src/schema/userTickets/tests/approvalUserTicket/approvalUserTicket.test.ts
@@ -1,6 +1,7 @@
 import { v4 } from "uuid";
 import { it, describe, assert } from "vitest";
 
+import { UserTicketApprovalStatus } from "~/datasources/db/userTickets";
 import {
   executeGraphqlOperationAsUser,
   insertEvent,
@@ -148,7 +149,7 @@ describe("Approval user ticket", () => {
     const ticket1 = await insertTicket({
       ticketTemplateId: ticketTemplate1.id,
       userId: user1.id,
-      approvalStatus: "approved",
+      approvalStatus: UserTicketApprovalStatus.Approved,
       purchaseOrderId: purchaseOrder.id,
     });
     const response = await executeGraphqlOperationAsUser<

--- a/src/schema/userTickets/tests/publicTicketInfo/publicTicketInfo.test.ts
+++ b/src/schema/userTickets/tests/publicTicketInfo/publicTicketInfo.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "vitest";
 
+import { UserTicketApprovalStatus } from "~/datasources/db/userTickets";
 import {
   executeGraphqlOperation,
   insertTicket,
@@ -18,7 +19,7 @@ describe("public user ticket information", () => {
     const ticketTemplate = await insertTicketTemplate();
     const user = await insertUser();
     const ticket = await insertTicket({
-      approvalStatus: "approved",
+      approvalStatus: UserTicketApprovalStatus.Approved,
       ticketTemplateId: ticketTemplate.id,
       userId: user.id,
     });
@@ -49,7 +50,7 @@ describe("public user ticket information", () => {
       const ticketTemplate = await insertTicketTemplate();
       const user = await insertUser();
       const ticket = await insertTicket({
-        approvalStatus: "pending",
+        approvalStatus: UserTicketApprovalStatus.Pending,
         ticketTemplateId: ticketTemplate.id,
         userId: user.id,
       });

--- a/src/schema/userTickets/tests/redeemUserTicket/redeemUserTicket.test.ts
+++ b/src/schema/userTickets/tests/redeemUserTicket/redeemUserTicket.test.ts
@@ -1,5 +1,6 @@
 import { it, describe, assert } from "vitest";
 
+import { UserTicketApprovalStatus } from "~/datasources/db/userTickets";
 import {
   executeGraphqlOperationAsUser,
   insertCommunity,
@@ -359,7 +360,7 @@ describe("Redeem user ticket", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "rejected",
+        approvalStatus: UserTicketApprovalStatus.Rejected,
       });
       const response = await executeGraphqlOperationAsUser<
         RedeemUserTicketMutation,
@@ -409,7 +410,7 @@ describe("Redeem user ticket", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "cancelled",
+        approvalStatus: UserTicketApprovalStatus.Cancelled,
       });
       const response = await executeGraphqlOperationAsUser<
         RedeemUserTicketMutation,

--- a/src/schema/userTickets/tests/triggerUserTicketApprovalReview/triggerUserTicketApprovalReview.test.ts
+++ b/src/schema/userTickets/tests/triggerUserTicketApprovalReview/triggerUserTicketApprovalReview.test.ts
@@ -3,7 +3,7 @@ import { it, describe, assert } from "vitest";
 
 import { TeamStatusEnum } from "~/datasources/db/teams";
 import { UserParticipationStatusEnum } from "~/datasources/db/userTeams";
-import { userTicketsApprovalStatusEnum } from "~/datasources/db/userTickets";
+import { UserTicketApprovalStatus } from "~/datasources/db/userTickets";
 import {
   executeGraphqlOperationAsUser,
   insertCommunity,
@@ -25,7 +25,7 @@ import {
 } from "./triggerUserTicketApprovalReview.generated";
 
 const prepareTickets = async (
-  status: (typeof userTicketsApprovalStatusEnum)[number] = "gifted",
+  status: UserTicketApprovalStatus = UserTicketApprovalStatus.Gifted,
   isTeamOnly = false,
 ) => {
   const community1 = await insertCommunity();
@@ -54,7 +54,10 @@ const prepareTickets = async (
 describe("triggerUserTicketApprovalReview mutation", () => {
   describe("It should approve tickets", () => {
     it("If data is complete for non-team tickets", async () => {
-      const { event, user } = await prepareTickets("gifted", false);
+      const { event, user } = await prepareTickets(
+        UserTicketApprovalStatus.Gifted,
+        false,
+      );
 
       await insertUserData({
         userId: user.id,
@@ -83,7 +86,10 @@ describe("triggerUserTicketApprovalReview mutation", () => {
     });
 
     it("If data is complete for team tickets", async () => {
-      const { event, user } = await prepareTickets("gifted", true);
+      const { event, user } = await prepareTickets(
+        UserTicketApprovalStatus.Gifted,
+        true,
+      );
       const team = await insertTeam({
         eventId: event.id,
         teamStatus: TeamStatusEnum.accepted,
@@ -126,7 +132,9 @@ describe("triggerUserTicketApprovalReview mutation", () => {
 
   describe("It should not approve tickets", () => {
     it("If ticket is not gifted", async () => {
-      const { event, user } = await prepareTickets("cancelled");
+      const { event, user } = await prepareTickets(
+        UserTicketApprovalStatus.Cancelled,
+      );
 
       await insertUserData({
         userId: user.id,
@@ -155,7 +163,10 @@ describe("triggerUserTicketApprovalReview mutation", () => {
     });
 
     it("If data is incomplete for non-team tickets", async () => {
-      const { event, user } = await prepareTickets("gifted", false);
+      const { event, user } = await prepareTickets(
+        UserTicketApprovalStatus.Gifted,
+        false,
+      );
 
       await insertUserData({
         userId: user.id,
@@ -181,7 +192,10 @@ describe("triggerUserTicketApprovalReview mutation", () => {
     });
 
     it("If data is incomplete for team tickets", async () => {
-      const { event, user } = await prepareTickets("gifted", true);
+      const { event, user } = await prepareTickets(
+        UserTicketApprovalStatus.Gifted,
+        true,
+      );
       const team = await insertTeam({
         eventId: event.id,
         teamStatus: TeamStatusEnum.accepted,
@@ -219,7 +233,10 @@ describe("triggerUserTicketApprovalReview mutation", () => {
     });
 
     it("If team is not accepted for team tickets", async () => {
-      const { event, user } = await prepareTickets("gifted", true);
+      const { event, user } = await prepareTickets(
+        UserTicketApprovalStatus.Gifted,
+        true,
+      );
       const team = await insertTeam({
         eventId: event.id,
         teamStatus: TeamStatusEnum.not_accepted,

--- a/src/schema/userTickets/tests/userTicketFetcher/userTicketFetcher.test.ts
+++ b/src/schema/userTickets/tests/userTicketFetcher/userTicketFetcher.test.ts
@@ -1,5 +1,9 @@
 import { assert, describe, it } from "vitest";
 
+import {
+  UserTicketApprovalStatus,
+  UserTicketRedemptionStatus,
+} from "~/datasources/db/userTickets";
 import { userTicketFetcher } from "~/schema/userTickets/userTicketFetcher";
 import {
   insertEvent,
@@ -39,9 +43,9 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2021-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
@@ -61,18 +65,18 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2022-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
 
       await insertTicket({
         ticketTemplateId: ticketTemplate1.id,
         userId: user2.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date(),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
@@ -97,18 +101,18 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2021-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
 
       await insertTicket({
         ticketTemplateId: ticketTemplate2.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2022-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
@@ -129,18 +133,18 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2021-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
 
       const ticket2 = await insertTicket({
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2022-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
@@ -163,23 +167,23 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2021-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
 
       await insertTicket({
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "pending",
+        approvalStatus: UserTicketApprovalStatus.Pending,
         createdAt: new Date("2022-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
         search: {
-          approvalStatus: ["approved"],
+          approvalStatus: [UserTicketApprovalStatus.Approved],
         },
       });
 
@@ -195,23 +199,23 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2021-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
 
       await insertTicket({
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2022-01-01"),
-        redemptionStatus: "pending",
+        redemptionStatus: UserTicketRedemptionStatus.Pending,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
         search: {
-          redemptionStatus: ["redeemed"],
+          redemptionStatus: [UserTicketRedemptionStatus.Redeemed],
         },
       });
 
@@ -227,25 +231,25 @@ describe("Search for user tickets", () => {
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2021-01-01"),
-        redemptionStatus: "redeemed",
+        redemptionStatus: UserTicketRedemptionStatus.Redeemed,
       });
 
       await insertTicket({
         ticketTemplateId: ticketTemplate1.id,
         userId: user1.id,
         purchaseOrderId: purchaseOrder.id,
-        approvalStatus: "approved",
+        approvalStatus: UserTicketApprovalStatus.Approved,
         createdAt: new Date("2022-01-01"),
-        redemptionStatus: "pending",
+        redemptionStatus: UserTicketRedemptionStatus.Pending,
       });
       const response = await userTicketFetcher.searchUserTickets({
         DB: testDB,
         search: {
           paymentStatus: ["paid"],
-          approvalStatus: ["approved"],
-          redemptionStatus: ["redeemed"],
+          approvalStatus: [UserTicketApprovalStatus.Approved],
+          redemptionStatus: [UserTicketRedemptionStatus.Redeemed],
         },
       });
 

--- a/src/schema/userTickets/types.ts
+++ b/src/schema/userTickets/types.ts
@@ -1,9 +1,9 @@
 import { builder } from "~/builder";
 import {
-  userTicketsApprovalStatusEnum,
   puchaseOrderPaymentStatusEnum,
-  userTicketsRedemptionStatusEnum,
   selectUsersSchema,
+  userTicketsApprovalStatusEnum,
+  userTicketsRedemptionStatusEnum,
 } from "~/datasources/db/schema";
 import {
   PurchaseOrderLoadable,

--- a/src/schema/userTickets/userTicketFetcher.ts
+++ b/src/schema/userTickets/userTicketFetcher.ts
@@ -8,8 +8,8 @@ import {
 } from "~/datasources/db/purchaseOrders";
 import { ticketsSchema } from "~/datasources/db/tickets";
 import {
-  userTicketsApprovalStatusEnum,
-  userTicketsRedemptionStatusEnum,
+  UserTicketApprovalStatus,
+  UserTicketRedemptionStatus,
   userTicketsSchema,
 } from "~/datasources/db/userTickets";
 import {
@@ -24,9 +24,9 @@ export type UserTicketSearch = {
   userTicketIds?: string[];
   ticketIds?: string[];
   eventName?: string;
-  approvalStatus?: (typeof userTicketsApprovalStatusEnum)[number][];
+  approvalStatus?: UserTicketApprovalStatus[];
   paymentStatus?: (typeof puchaseOrderPaymentStatusEnum)[number][];
-  redemptionStatus?: (typeof userTicketsRedemptionStatusEnum)[number][];
+  redemptionStatus?: UserTicketRedemptionStatus[];
 };
 
 const getSearchUserTicketsQuery = (

--- a/src/schema/waitlist/tests/fetchWaitlist.test.ts
+++ b/src/schema/waitlist/tests/fetchWaitlist.test.ts
@@ -1,5 +1,6 @@
 import { describe, assert, it } from "vitest";
 
+import { UserTicketApprovalStatus } from "~/datasources/db/userTickets";
 import {
   FetchWaitlist,
   FetchWaitlistQuery,
@@ -33,7 +34,7 @@ describe("Should get my ticket for a waitlist", () => {
     const userTicket = await insertTicket({
       ticketTemplateId: ticket.id,
       purchaseOrderId: purchaseOrder.id,
-      approvalStatus: "pending",
+      approvalStatus: UserTicketApprovalStatus.Pending,
     });
 
     await insertEventToCommunity({

--- a/src/tests/fixtures/index.ts
+++ b/src/tests/fixtures/index.ts
@@ -15,7 +15,10 @@ import { ZodType, z } from "zod";
 import { Env } from "worker-configuration";
 import * as rules from "~/authz";
 import {
+  InsertUserTicketSchema,
   PronounsEnum,
+  UserTicketApprovalStatus,
+  UserTicketRedemptionStatus,
   allowedCurrencySchema,
   communitySchema,
   companiesSchema,
@@ -507,10 +510,7 @@ export const insertPurchaseOrder = async (
 };
 
 export const insertTicket = async (
-  partialInput?: Omit<
-    z.infer<typeof insertUserTicketsSchema>,
-    "id" | "purchaseOrderId"
-  > & {
+  partialInput?: Omit<InsertUserTicketSchema, "id" | "purchaseOrderId"> & {
     id?: string;
     purchaseOrderId?: string;
   },
@@ -523,11 +523,11 @@ export const insertTicket = async (
     ticketTemplateId:
       partialInput?.ticketTemplateId ?? (await insertTicketTemplate()).id,
     approvalStatus:
-      partialInput?.approvalStatus ?? TicketApprovalStatus.Pending,
+      partialInput?.approvalStatus ?? UserTicketApprovalStatus.Pending,
     redemptionStatus:
-      partialInput?.redemptionStatus ?? TicketRedemptionStatus.Pending,
+      partialInput?.redemptionStatus ?? UserTicketRedemptionStatus.Pending,
     ...CRUDDates(partialInput),
-  } satisfies z.infer<typeof insertUserTicketsSchema>;
+  } satisfies InsertUserTicketSchema;
 
   return insertOne(
     insertUserTicketsSchema,


### PR DESCRIPTION
Este PR propone re-factorizar cómo manejamos los estados de los tickets de usuario (UserTicket).
Los principales cambios y ventajas que veo con este cambio son los siguientes:

1. **Introducción de enums**: Se han creado `UserTicketApprovalStatus` y `UserTicketRedemptionStatus` reemplazando las cadenas de texto literales.

2. **Facilidad de navegación en el código**: 
   - Ahora es posible encontrar fácilmente todos los usos de cada estado utilizando CMD + click (o su equivalente) en el estado correspondiente, lo que mejora la capacidad de rastrear y entender el flujo de los estados.

3. **Documentación inline mejorada**: 
   - Los enums permiten añadir documentación directamente a cada estado, algo que no era posible con los strings constantes anteriores.
   - Esto facilita entender el propósito y uso de cada estado directamente en el código.

4. **Mantenimiento de la seguridad de tipos**:
   - Aunque TypeScript ya proporcionaba seguridad de tipos y autocompletado con los strings constantes, los enums mantienen estas ventajas mientras añaden las mencionadas anteriormente.

5. **Actualización del código y pruebas**: 
   - Se ha actualizado el código en toda la base para utilizar estos nuevos enums.

### Puntos para discusión:
Como verán definí una documentación inicial para cada estado pero no tengo claro cual era la idea con algunos estados como "rejected" o "gift_accepted", por lo que necesitaría de su ayuda para definir esa documentación.