### PR TITLE
Exposing images on event schemas

### DIFF
--- a/src/generated/schema.gql
+++ b/src/generated/schema.gql
@@ -146,6 +146,7 @@ Representation of an Event (Events and Users, is what tickets are linked to)
 """
 type Event {
   address: String
+  bannerImage: Image
   bannerImageSanityRef: String
   community: Community
   description: String
@@ -156,7 +157,9 @@ type Event {
   latitude: String
   longitude: String
   meetingURL: String
+  mobileBannerImage: Image
   name: String!
+  previewImage: Image
   schedules: [Schedule!]!
   speakers: [Speaker!]!
   startDateTime: DateTime!

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -162,6 +162,7 @@ export type EnqueueGoogleAlbumImportInput = {
 export type Event = {
   __typename?: "Event";
   address?: Maybe<Scalars["String"]["output"]>;
+  bannerImage?: Maybe<Image>;
   bannerImageSanityRef?: Maybe<Scalars["String"]["output"]>;
   community?: Maybe<Community>;
   description?: Maybe<Scalars["String"]["output"]>;
@@ -172,7 +173,9 @@ export type Event = {
   latitude?: Maybe<Scalars["String"]["output"]>;
   longitude?: Maybe<Scalars["String"]["output"]>;
   meetingURL?: Maybe<Scalars["String"]["output"]>;
+  mobileBannerImage?: Maybe<Image>;
   name: Scalars["String"]["output"];
+  previewImage?: Maybe<Image>;
   schedules: Array<Schedule>;
   speakers: Array<Speaker>;
   startDateTime: Scalars["DateTime"]["output"];

--- a/src/schema/events/types.ts
+++ b/src/schema/events/types.ts
@@ -6,6 +6,7 @@ import {
   ScheduleStatus,
   selectCommunitySchema,
   selectGalleriesSchema,
+  selectImagesSchema,
   selectScheduleSchema,
   selectSpeakerSchema,
   selectTagsSchema,
@@ -21,6 +22,7 @@ import {
 import { getImagesBySanityEventId } from "~/datasources/sanity/images";
 import { eventsFetcher } from "~/schema/events/eventsFetcher";
 import { GalleryRef } from "~/schema/gallery/types";
+import { ImageRef } from "~/schema/image/types";
 import { schedulesFetcher } from "~/schema/schedules/schedulesFetcher";
 import { ScheduleRef } from "~/schema/schedules/types";
 import {
@@ -148,6 +150,63 @@ export const EventLoadable = builder.loadableObject(EventRef, {
           client,
           sanityEventId,
         });
+      },
+    }),
+    previewImage: t.field({
+      type: ImageRef,
+      nullable: true,
+      resolve: async ({ previewImage }, args, { DB, logger }) => {
+        if (!previewImage) {
+          return null;
+        }
+
+        const image = await DB.query.imagesSchema.findFirst({
+          where: (i, { eq }) => eq(i.id, previewImage),
+        });
+
+        if (!image) {
+          return null;
+        }
+
+        return selectImagesSchema.parse(image);
+      },
+    }),
+    bannerImage: t.field({
+      type: ImageRef,
+      nullable: true,
+      resolve: async ({ bannerImage }, args, { DB }) => {
+        if (!bannerImage) {
+          return null;
+        }
+
+        const image = await DB.query.imagesSchema.findFirst({
+          where: (i, { eq }) => eq(i.id, bannerImage),
+        });
+
+        if (!image) {
+          return null;
+        }
+
+        return selectImagesSchema.parse(image);
+      },
+    }),
+    mobileBannerImage: t.field({
+      type: ImageRef,
+      nullable: true,
+      resolve: async ({ mobileBannerImage }, args, { DB }) => {
+        if (!mobileBannerImage) {
+          return null;
+        }
+
+        const image = await DB.query.imagesSchema.findFirst({
+          where: (i, { eq }) => eq(i.id, mobileBannerImage),
+        });
+
+        if (!image) {
+          return null;
+        }
+
+        return selectImagesSchema.parse(image);
       },
     }),
     teams: t.field({

--- a/src/schema/purchaseOrder/tests/checkPurchaseOrderStatus.generated.ts
+++ b/src/schema/purchaseOrder/tests/checkPurchaseOrderStatus.generated.ts
@@ -11,7 +11,7 @@ export type CheckPurchaseOrderStatusMutationVariables = Types.Exact<{
 }>;
 
 
-export type CheckPurchaseOrderStatusMutation = { __typename?: 'Mutation', checkPurchaseOrderStatus: { __typename?: 'PurchaseOrder', id: string, status: Types.PurchaseOrderStatusEnum | null, paymentPlatform: string | null, purchasePaymentStatus: Types.PurchaseOrderPaymentStatusEnum | null, finalPrice: number | null, currency: { __typename?: 'AllowedCurrency', currency: string } | null } };
+export type CheckPurchaseOrderStatusMutation = { __typename?: 'Mutation', checkPurchaseOrderStatus: { __typename?: 'PurchaseOrder', id: string, status: Types.PurchaseOrderStatusEnum | null, paymentPlatform: string | null, purchasePaymentStatus: Types.PurchaseOrderPaymentStatusEnum | null, finalPrice: number | null, currency: { __typename?: 'AllowedCurrency', id: string, currency: string } | null } };
 
 
 export const CheckPurchaseOrderStatus = gql`
@@ -20,12 +20,12 @@ export const CheckPurchaseOrderStatus = gql`
     id
     status
     currency {
+      id
       currency
     }
     paymentPlatform
     purchasePaymentStatus
     finalPrice
-    status
   }
 }
     `;


### PR DESCRIPTION
PR is a followup on https://github.com/JSConfCL/gql_api/commit/9008d636b8c63d22555bc08934cace04d283612c 

PR will expose information for specific event images on graphql endpoints, so we can replicate things like these UIs.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/c22cf915-8f85-4148-95e3-0860436e2866">


#### https://api.jsconf.dev/graphql?query=query+eventData+%7B%0A++event%28id%3A+%22390a90ec-0810-466f-b6fa-5b1c0df32bdf%22%29+%7B%0A++++status%0A++++name%0A++++description%0A++++previewImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++++bannerImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++++mobileBannerImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++%7D%0A%7D

```
query eventData {
  event(id: "390a90ec-0810-466f-b6fa-5b1c0df32bdf") {
    status
    name
    description
    previewImage {
      id
      url
      hosting
    }
    bannerImage {
      id
      url
      hosting
    }
    mobileBannerImage {
      id
      url
      hosting
    }
  }
}
```