### PR TITLE
Exposing logoImage

### DIFF
--- a/src/generated/schema.gql
+++ b/src/generated/schema.gql
@@ -155,6 +155,7 @@ type Event {
   id: ID!
   images: [SanityAssetRef!]!
   latitude: String
+  logoImage: Image
   longitude: String
   meetingURL: String
   mobileBannerImage: Image

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -171,6 +171,7 @@ export type Event = {
   id: Scalars["ID"]["output"];
   images: Array<SanityAssetRef>;
   latitude?: Maybe<Scalars["String"]["output"]>;
+  logoImage?: Maybe<Image>;
   longitude?: Maybe<Scalars["String"]["output"]>;
   meetingURL?: Maybe<Scalars["String"]["output"]>;
   mobileBannerImage?: Maybe<Image>;

--- a/src/schema/events/types.ts
+++ b/src/schema/events/types.ts
@@ -152,6 +152,25 @@ export const EventLoadable = builder.loadableObject(EventRef, {
         });
       },
     }),
+    logoImage: t.field({
+      type: ImageRef,
+      nullable: true,
+      resolve: async ({ logoImage }, args, { DB, logger }) => {
+        if (!logoImage) {
+          return null;
+        }
+
+        const image = await DB.query.imagesSchema.findFirst({
+          where: (i, { eq }) => eq(i.id, logoImage),
+        });
+
+        if (!image) {
+          return null;
+        }
+
+        return selectImagesSchema.parse(image);
+      },
+    }),
     previewImage: t.field({
       type: ImageRef,
       nullable: true,


### PR DESCRIPTION
PR is a followup on https://github.com/JSConfCL/gql_api/pull/277

PR will expose information for specific event images on graphql endpoints, so we can replicate things like these UIs.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/c22cf915-8f85-4148-95e3-0860436e2866">



#### https://api.jsconf.dev/graphql?query=query+eventData+%7B%0A++event%28id%3A+%22390a90ec-0810-466f-b6fa-5b1c0df32bdf%22%29+%7B%0A++++status%0A++++name%0A++++description%0A++++logoImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++++previewImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++++bannerImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++++mobileBannerImage+%7B%0A++++++id%0A++++++url%0A++++++hosting%0A++++%7D%0A++%7D%0A%7D

```GQL
query eventData {
  event(id: "390a90ec-0810-466f-b6fa-5b1c0df32bdf") {
    status
    name
    description
    logoImage {
      id
      url
      hosting
    }
    previewImage {
      id
      url
      hosting
    }
    bannerImage {
      id
      url
      hosting
    }
    mobileBannerImage {
      id
      url
      hosting
    }
  }
}
```