### PR TITLE
fix: status "complete" when purchase order payment is not_required on createPaymentIntent

### DIFF
--- a/src/schema/purchaseOrder/actions.tsx
+++ b/src/schema/purchaseOrder/actions.tsx
@@ -405,6 +405,7 @@ export const createPaymentIntent = async ({
     );
     const updatedPOs = await DB.update(purchaseOrdersSchema)
       .set({
+        status: "complete",
         purchaseOrderPaymentStatus: "not_required",
       })
       .where(eq(purchaseOrdersSchema.id, purchaseOrderId))


### PR DESCRIPTION
Este PR modifica la función `createPaymentIntent` para permitir que la consulta "myPurchaseOrders" incluya las órdenes de compra que tienen `purchaseOrderPaymentStatus: "not_required"`.

Cambio realizado:
- En la función `createPaymentIntent`, cuando se detecta que todos los tickets son gratuitos, ahora se actualiza el estado de la orden a `status: "complete"`, además de mantener `purchaseOrderPaymentStatus: "not_required"`.

Contexto:
Anteriormente, las órdenes con `purchaseOrderPaymentStatus: "not_required"` no iban a aparecer en "myPurchaseOrders" ya que esta query solo filtra por las PurchaseOrders con estado "complete". Este cambio asegura su inclusión.
https://github.com/JSConfCL/gql_api/blob/4bf644fb932709af661d2754a7c603f47f4b5514/src/schema/purchaseOrder/queries.ts#L35-L47