### PR TITLE
fix: Validación de addons en claimUserTicketAddons

### DIFF
--- a/src/schema/userTicketsAddons/mutations.ts
+++ b/src/schema/userTicketsAddons/mutations.ts
@@ -132,20 +132,6 @@ builder.mutationField("claimUserTicketAddons", (t) =>
           for (const [userTicketId, claims] of Object.entries(claimsByTicket)) {
             const userTicket = userTickets.find((ut) => ut.id === userTicketId);
 
-            logger.debug("User ticket:", JSON.stringify(userTicket, null, 2));
-
-            logger.debug(
-              "Raw aggregatedAddons:",
-              JSON.stringify(
-                aggregatedAddons.map((a) => ({
-                  addonId: a.id,
-                  ticketId: a.ticketId,
-                })),
-                null,
-                2,
-              ),
-            );
-
             const validAddons = aggregatedAddons.filter(
               (ta) => ta.ticketId === userTicket?.ticketTemplate.id,
             );

--- a/src/schema/userTicketsAddons/mutations.ts
+++ b/src/schema/userTicketsAddons/mutations.ts
@@ -111,36 +111,41 @@ builder.mutationField("claimUserTicketAddons", (t) =>
 
           const [
             createdPurchaseOrder,
-            userTickets,
-            aggregatedAddons,
-            claimedAddonsByUserTicketId,
+            { userTickets, aggregatedAddons, claimedAddonsByUserTicketId },
           ] = await Promise.all([
             createInitialPurchaseOrder({
               DB: trx,
               userId: USER.id,
               logger,
             }),
-            claimUserTicketAddonsHelpers.fetchAndValidateUserTickets({
+            claimUserTicketAddonsHelpers.fetchAndValidateTicketData({
               trx,
               userTicketIds: uniqueUserTicketIds,
               userId: USER.id,
               logger,
-            }),
-            claimUserTicketAddonsHelpers.fetchAndValidateAggregatedAddons({
-              trx,
-              currencyId,
-              logger,
               addonIds: addonsClaims.map((a) => a.addonId),
-            }),
-            claimUserTicketAddonsHelpers.fetchClaimedAddonsByUserTicketId({
-              trx,
-              userTicketIds: uniqueUserTicketIds,
+              currencyId,
             }),
           ]);
 
           // validate that all addons constraints are respected
           for (const [userTicketId, claims] of Object.entries(claimsByTicket)) {
             const userTicket = userTickets.find((ut) => ut.id === userTicketId);
+
+            logger.debug("User ticket:", JSON.stringify(userTicket, null, 2));
+
+            logger.debug(
+              "Raw aggregatedAddons:",
+              JSON.stringify(
+                aggregatedAddons.map((a) => ({
+                  addonId: a.id,
+                  ticketId: a.ticketId,
+                })),
+                null,
+                2,
+              ),
+            );
+
             const validAddons = aggregatedAddons.filter(
               (ta) => ta.ticketId === userTicket?.ticketTemplate.id,
             );


### PR DESCRIPTION
### Problema
Al intentar reclamar addons a través de la mutación `claimUserTicketAddons`, el sistema estaba fallando porque no se incluían todos los addons relacionados al ticket en la validación.

Específicamente:
- Solo se traía la información de los addons que el usuario quería reclamar
- Si el ticket del usuario ya tenía asociados otros addons, se necesitaba la información de las asociaciones para validar las restricciones
- Al no estar trayendo la información de los addons ya reclamados para el ticket, el sistema informaba erróneamente que el addon no estaba relacionado al ticket template correspondiente

Este problema ocurría porque:
1. La función `fetchAndValidateAggregatedAddons` solo buscaba los addons nuevos que se querían reclamar
2. Al validar las restricciones, necesitamos la información de addons nuevos que se van a relacionar al ticket y los ya relacionados para verificar:
   - Dependencias: si un addon requiere que otro esté presente
   - Exclusiones mutuas: si dos addons no pueden estar juntos

### Solución
Se unificó la lógica de fetching de datos en una sola función `fetchAndValidateTicketData` que ahora:
1. Obtiene los tickets del usuario
2. Recupera todos los addons ya reclamados para estos tickets
3. Combina los IDs de los addons nuevos y existentes
4. Busca toda la información necesaria de los addons y sus relaciones con el ticket template

### Cambios detallados
- Se eliminó la función `fetchAndValidateAggregatedAddons` separada
- Se creó una nueva función `fetchAndValidateTicketData` que:
  ```typescript
  // Obtiene IDs de addons ya reclamados
  const allClaimedAddonIds = Object.values(claimedAddonsByUserTicketId)
    .flat()
    .map((claim) => claim.addonId);

  // Combina con los nuevos addons a reclamar
  const allAddonIds = [...new Set([...addonIds, ...allClaimedAddonIds])];

  // Busca toda la información necesaria
  const aggregatedAddons = await trx.query.ticketAddonsSchema.findMany({
    where: (t, ops) =>
      ops.and(
        ops.inArray(t.addonId, allAddonIds),
        ops.inArray(t.ticketId, ticketTemplateIds),
      ),
    // ... resto de la query
  });
  ```

### Impacto
- Se verifican apropiadamente todas las restricciones entre addons
- No hay falsos negativos al validar relaciones con el ticket template

### Tests
Se agregaron pruebas que cubren:
- Reclamo de addons cuando ya existen otros reclamados
- Validación correcta de dependencias con addons existentes
- Validación correcta de exclusiones mutuas
- Casos de error cuando faltan dependencias
- Casos de error cuando hay conflictos de exclusión mutua