### PR TITLE
fix: Actualizar estado de orden de compra para addons gratuitos

### DIFF
--- a/src/schema/userTicketsAddons/mutations.ts
+++ b/src/schema/userTicketsAddons/mutations.ts
@@ -1,9 +1,11 @@
+import { eq } from "drizzle-orm";
 import { GraphQLError } from "graphql";
 
 import { builder } from "~/builder";
 import {
   userTicketAddonsSchema,
   selectPurchaseOrdersSchema,
+  purchaseOrdersSchema,
 } from "~/datasources/db/schema";
 import { applicationError, ServiceErrors } from "~/errors";
 import { handlePaymentLinkGeneration } from "~/schema/purchaseOrder/actions";
@@ -207,6 +209,15 @@ builder.mutationField("claimUserTicketAddons", (t) =>
               USER: USER,
             });
           }
+
+          await trx
+            .update(purchaseOrdersSchema)
+            .set({
+              purchaseOrderPaymentStatus: "not_required",
+              status: "complete",
+              totalPrice: "0",
+            })
+            .where(eq(purchaseOrdersSchema.id, createdPurchaseOrder.id));
 
           return {
             purchaseOrder:

--- a/src/schema/userTicketsAddons/tests/claimUserTicketAddons.generated.ts
+++ b/src/schema/userTicketsAddons/tests/claimUserTicketAddons.generated.ts
@@ -12,7 +12,7 @@ export type ClaimUserTicketAddonsMutationVariables = Types.Exact<{
 }>;
 
 
-export type ClaimUserTicketAddonsMutation = { __typename?: 'Mutation', claimUserTicketAddons: { __typename: 'PurchaseOrder', id: string, status: Types.PurchaseOrderStatusEnum | null, paymentLink: string | null, userTicketAddons: Array<{ __typename?: 'UserTicketAddon', id: string, userTicketId: string, addonId: string, quantity: number }> } | { __typename: 'RedeemUserTicketAddonsError', error: boolean, errorMessage: string } };
+export type ClaimUserTicketAddonsMutation = { __typename?: 'Mutation', claimUserTicketAddons: { __typename: 'PurchaseOrder', id: string, status: Types.PurchaseOrderStatusEnum | null, purchasePaymentStatus: Types.PurchaseOrderPaymentStatusEnum | null, paymentLink: string | null, userTicketAddons: Array<{ __typename?: 'UserTicketAddon', id: string, userTicketId: string, addonId: string, quantity: number }> } | { __typename: 'RedeemUserTicketAddonsError', error: boolean, errorMessage: string } };
 
 
 export const ClaimUserTicketAddons = gql`
@@ -22,6 +22,7 @@ export const ClaimUserTicketAddons = gql`
     ... on PurchaseOrder {
       id
       status
+      purchasePaymentStatus
       paymentLink
       userTicketAddons {
         id

--- a/src/schema/userTicketsAddons/tests/claimUserTicketAddons.gql
+++ b/src/schema/userTicketsAddons/tests/claimUserTicketAddons.gql
@@ -7,6 +7,7 @@ mutation ClaimUserTicketAddons(
     ... on PurchaseOrder {
       id
       status
+      purchasePaymentStatus
       paymentLink
       userTicketAddons {
         id


### PR DESCRIPTION
Este PR corrige el comportamiento de las órdenes de compra cuando se reclaman addons gratuitos.
Anteriormente, las órdenes de compra para addons gratuitos quedaban en un estado incorrecto.

### Cambios principales
- Se actualiza el estado de la orden de compra a "complete" cuando solo se reclaman addons gratuitos
- Se establece el estado de pago como "not_required" para addons gratuitos
- Se establece el precio total en "0" para addons gratuitos
- Se añaden pruebas para verificar el comportamiento tanto para addons gratuitos como pagados