### PR TITLE
fix: Corrige cálculo de stock en addons y actualiza estado de addons en órdenes vencidas

### DIFF
--- a/src/schema/purchaseOrder/actions.tsx
+++ b/src/schema/purchaseOrder/actions.tsx
@@ -1185,6 +1185,18 @@ export const clearExpiredPurchaseOrders = async ({
         ),
       )
       .returning();
+
+    await DB.update(userTicketAddonsSchema)
+      .set({
+        approvalStatus: UserTicketAddonApprovalStatus.CANCELLED,
+      })
+      .where(
+        inArray(
+          userTicketAddonsSchema.purchaseOrderId,
+          expiredOrders.map((po) => po.id),
+        ),
+      )
+      .returning();
   }
 
   return expiredOrders;

--- a/src/schema/ticketAddons/types.ts
+++ b/src/schema/ticketAddons/types.ts
@@ -82,35 +82,15 @@ builder.objectType(AddonRef, {
           return null;
         }
 
-        const userTickets = await DB.query.userTicketsSchema.findMany({
-          where: (ut, { eq, and, inArray }) =>
-            and(
-              eq(ut.ticketTemplateId, root.id),
-              inArray(ut.approvalStatus, [
-                "approved",
-                "not_required",
-                "pending",
-                "gifted",
-                "gift_accepted",
-                "transfer_accepted",
-                "transfer_pending",
-              ]),
-            ),
-        });
-
-        if (userTickets.length === 0) {
-          return root.totalStock;
-        }
-
         const userTicketAddons = await DB.query.userTicketAddonsSchema.findMany(
           {
             where: (ut, ops) =>
               ops.and(
                 ops.eq(ut.addonId, root.id),
-                ops.inArray(
-                  ut.userTicketId,
-                  userTickets.map((ut) => ut.id),
-                ),
+                ops.inArray(ut.approvalStatus, [
+                  UserTicketAddonApprovalStatus.APPROVED,
+                  UserTicketAddonApprovalStatus.PENDING,
+                ]),
               ),
           },
         );


### PR DESCRIPTION
Este PR introduce dos cambios importantes relacionados con los addons:

1. Corrige el cálculo de stock disponible para addons:
   - Solo considera addons con estado APPROVED o PENDING para el cálculo
   - Corrige y simplifica el calculo

2. Actualiza el estado de los addons cuando una orden de compra expira:
   - Al marcar una orden como vencida, los addons asociados se actualizan a estado CANCELLED
   - Esto mantiene la consistencia de datos entre órdenes y addons además de permitir correctamente el calculo del stock para el addon