### PR TITLE
feat: more logs on syncPurchaseOrderPaymentStatus

### DIFF
--- a/src/schema/purchaseOrder/actions.tsx
+++ b/src/schema/purchaseOrder/actions.tsx
@@ -1020,6 +1020,7 @@ export const syncPurchaseOrderPaymentStatus = async ({
     const stripeStatus = await getStripePaymentStatus({
       paymentId: paymentPlatformReferenceID,
       getStripeClient: GET_STRIPE_CLIENT,
+      logger,
     });
 
     poPaymentStatus = stripeStatus.paymentStatus;
@@ -1031,12 +1032,18 @@ export const syncPurchaseOrderPaymentStatus = async ({
     const mercadoPagoStatus = await getMercadoPagoPayment({
       purchaseOrderId: purchaseOrder.id,
       getMercadoPagoClient: GET_MERCADOPAGO_CLIENT,
+      logger,
     });
 
     poPaymentStatus = mercadoPagoStatus.paymentStatus;
 
     poStatus = mercadoPagoStatus.status ?? poStatus;
   }
+
+  logger.info(`New purchase order ${purchaseOrderId} status`, {
+    poPaymentStatus,
+    poStatus,
+  });
 
   if (
     poPaymentStatus !== purchaseOrder.purchaseOrderPaymentStatus ||


### PR DESCRIPTION
Hay un caso en el que el purchase order fue pagado pero el estado no se está actualizando correctamente a través del worker de sicronización de estado de compra.
Estos logs permitirán debuggear mejor estos casos.