### PR TITLE
fix: drizzle studio info to infer relation coupons to tickets

### DIFF
--- a/src/datasources/db/tickets.ts
+++ b/src/datasources/db/tickets.ts
@@ -74,6 +74,10 @@ export const ticketRelations = relations(ticketsSchema, ({ one, many }) => ({
   userTickets: many(userTicketsSchema),
   ticketsPrices: many(ticketsPricesSchema),
   ticketAddons: many(ticketAddonsSchema),
+  coupon: one(couponsSchema, {
+    fields: [ticketsSchema.couponId],
+    references: [couponsSchema.id],
+  }),
 }));
 
 export const selectTicketSchema = createSelectSchema(ticketsSchema, {


### PR DESCRIPTION
This PR fixes the error:
`Error: There is not enough information to infer relation "__public__.couponsSchema.tickets"`

When trying to run `npm run db:studio`